### PR TITLE
feat(buffer): Allowes buffers as payload data and metadata.

### DIFF
--- a/lib/protocol/frame/encodePayload.js
+++ b/lib/protocol/frame/encodePayload.js
@@ -5,9 +5,9 @@ var METADATA_LENGTH = require('./../constants').METADATA_LENGTH;
 
 /**
  * Encodes a payload into a buffer
- * @param {Object} payload The payload.
- * @param {String} payload.metadata The metadata.
- * @param {String} payload.data The data.
+ * @param {object} payload The payload.
+ * @param {string|Buffer} payload.metadata The metadata.
+ * @param {string|Buffer} payload.data The data.
  *
  * @returns {Buffer} The encoded payload frame.
  */
@@ -43,13 +43,23 @@ module.exports = function encodePayload(payload) {
         buf.writeUInt32BE(mdLength, offset);
         offset += METADATA_LENGTH;
 
-        buf.write(payload.metadata, offset);
+        bufferWrite(buf, payload.metadata, offset);
         offset += mdLength;
     }
 
     // Finally, writes the data payload at the offset.
-    buf.write(payload.data, offset);
+    bufferWrite(buf, payload.data, offset);
 
     LOG.debug({frame: buf, length: buf.length}, 'encodePayload: exiting');
     return buf;
 };
+
+function bufferWrite(targetBuffer, sourceBuffer, targetOffset) {
+    var type = typeof sourceBuffer;
+    if (type === 'string') {
+        targetBuffer.write(sourceBuffer, targetOffset);
+        return;
+    }
+
+    sourceBuffer.copy(targetBuffer, targetOffset, 0);
+}

--- a/lib/streams/ReactiveClient.js
+++ b/lib/streams/ReactiveClient.js
@@ -104,8 +104,8 @@ ReactiveClient.prototype._conEstablished = function _conEstablished(opts) {
 /**
  * Takes in a payload that will be encoded and sent to the underlying stream.
  * @param {Object} data -
- * @param {string} data.data - The data to be sent
- * @param {string} data.metadata - The meta to be sent
+ * @param {string|Buffer} data.data - The data to be sent
+ * @param {string|Buffer} data.metadata - The meta to be sent
  * @param {Function} [callback] -
  * @returns {undefined} -
  */

--- a/lib/streams/ReactiveServer.js
+++ b/lib/streams/ReactiveServer.js
@@ -193,9 +193,11 @@ ReactiveServer.prototype._notifyListeners = function _notifyListeners(stream,
  *
  * @private
  * @param {Duplex} stream -
- * @param {Number} streamId -
- * @param {Object} payload -
- * @param {Boolean} isCompleted -
+ * @param {number} streamId -
+ * @param {object} payload -
+ * @param {Buffer} payload.data -
+ * @param {Buffer} payload.metadata -
+ * @param {boolean} isCompleted -
  * @returns {undefined}
  */
 ReactiveServer.prototype._respond = function _respond(stream, streamId,

--- a/lib/streams/SingleResponse.js
+++ b/lib/streams/SingleResponse.js
@@ -18,13 +18,20 @@ module.exports = SingleResponse;
 
 /**
  * Respond to the previous request
- * @param {String} data -
- * @param {String} metadata -
+ * @param {String|Buffer} data -
+ * @param {String|Buffer} metadata -
  * @returns {undefined}
  */
 SingleResponse.prototype.respond = function respond(data, metadata) {
     if (this._hasResponded) {
         throw new Error('Cannot respond to a request twice.');
+    }
+
+    if (typeof data === 'string') {
+        data = new Buffer(data);
+    }
+    if (typeof metadata === 'string') {
+        metadata = new Buffer(metadata);
     }
 
     this._hasResponded = true;

--- a/test/frame/Request.spec.js
+++ b/test/frame/Request.spec.js
@@ -34,4 +34,15 @@ describe('Request Response', function() {
 
             compareFrames(expected, actual);
         });
+
+    it('Request Frame -- create a req-res frame with meta (buffer)',
+        function() {
+            var expected = data.reqResFrameWithMeta;
+            var actual = Frame.getReqResFrame(data.STREAM_ID, {
+                data: new Buffer(data.REQ_RES_DATA),
+                metadata: new Buffer(data.REQ_RES_META)
+            });
+
+            compareFrames(expected, actual);
+        });
 });

--- a/test/frame/Response.spec.js
+++ b/test/frame/Response.spec.js
@@ -38,6 +38,17 @@ describe('Response Frame', function() {
 
             compareFrames(expected, actual);
         });
+
+    it('should create a res frame with data and meta and completed (buffer).',
+        function() {
+            var expected = setFlag(data.responseFrameWithMeta, COMPLETE);
+            var actual = Frame.getResponseFrame(data.STREAM_ID, {
+                data: new Buffer(data.RES_DATA),
+                metadata: new Buffer(data.RES_META)
+            }, true);
+
+            compareFrames(expected, actual);
+        });
 });
 
 


### PR DESCRIPTION
This will be useful as we test, if we do, other serialization formats.