### PR TITLE
fix(memory): fill(0) was forgotten in expected data.

### DIFF
--- a/test/data/responseFrame.js
+++ b/test/data/responseFrame.js
@@ -24,7 +24,7 @@ module.exports = {
 };
 
 function responseFrame() {
-    var reqResBuffer = new Buffer(12);
+    var reqResBuffer = new Buffer(12).fill(0);
 
     // 12 bytes of data (0xc)
     reqResBuffer.writeUInt32BE(0xc, 0); // 4 bytes of data


### PR DESCRIPTION
```javascript
var a = new Buffer(len)
console.log(a);
```

This above allocation can cause odd issues because `a`'s values are non
deterministic, as they can be filled with previous memory.  Instead the
allocation should look like `new Buffer(len).fill(0);` to zero out
header buffers.