### PR TITLE
[do not merge] Spec interpretation mismatch with the Java Impl

### DIFF
--- a/lib/protocol/frame/payload.js
+++ b/lib/protocol/frame/payload.js
@@ -69,7 +69,7 @@ function encodePayload(payload, metadataEncoding, dataEncoding) {
     if (payload.metadata) {
 
         // Writes the length of the metadata no matter what.
-        buf.writeUInt32BE(mdBuf.length, offset);
+        buf.writeUInt32BE(mdBuf.length + METADATA_LENGTH, offset);
         offset += METADATA_LENGTH;
 
         mdBuf.copy(buf, offset);


### PR DESCRIPTION
Not sure if this is a bug in the JS impl yet or not, but we need to sync up with the Java Impl, regarding how to handle the case when we have meta-data.

The Java impl is currently interpreting the size of the meta-data to be = (size of the metadata) + (size of the metadata length field length)

As a result we're 4 bits off where they think the meta-data ends, and where the payload begins. This change fixes things, so that everything works end-to-end with the Java implementation. Without it my request/response frames weren't being parsed correctly.

**As mentioned, don't merge this yet**, just want to provide the data point, so we can discuss it with the Java team and get it sync. If we do end up changing it on the JS side, I'll probably need to update tests, and the corresponding request frame handling code for JS (that is, when the JS client walks the the Buffer frame it receives). Actually, hopefully it fails the unit tests with this change.