### PR TITLE
Fixed setup data. Added tests. Fixed bug with original test setup

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -292,8 +292,8 @@ Connection.prototype.setup = function setup(su, cb) {
         version: CONSTANTS.VERSION,
         metadataEncoding: self._metadataEncoding,
         dataEncoding: self._dataEncoding,
-        metadata: su.setupMetadata,
-        data: su.setupData
+        metadata: su.metadata,
+        data: su.data
     }, cb);
 
     return self._setupStream;


### PR DESCRIPTION
* Fixed bug with setupData, setupMetadata support.

* Added unit test for both framed/unframed connection tests, and grouped all setupFrame tests together with their own setup/teardown, instead of hacking at the shared server/connection for the other tests.

* Fixed bug in original test's `before` handler.

    When I moved the `extra setup frame` test to another suite, the first `req/res` test started failing. Turns out it depended on the `extra setup frame` being run before it. If the order was different it would have failed also (if the extra setup frame test was run after it). Turns out we weren't waiting for connection 'ready' before running the tests.