### PR TITLE
Add support for LEASE frame

### DIFF
--- a/lib/protocol/frame/getLeaseFrame.js
+++ b/lib/protocol/frame/getLeaseFrame.js
@@ -15,7 +15,7 @@ var TYPES = CONSTANTS.TYPES;
  * @param {Number} frame.budget Number of requests granted.
  * @param {String} [frame.metadata=null] The metadata.
  *
- * @returns {Buffer} The encoded error frame.
+ * @returns {Buffer} The encoded lease frame.
  */
 module.exports = function getLeaseFrame(frame) {
     assert.object(frame, 'frame');

--- a/lib/protocol/frame/getLeaseFrame.js
+++ b/lib/protocol/frame/getLeaseFrame.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var assert = require('assert-plus');
+
+var getFrameHeader = require('./getFrameHeader');
+
+var CONSTANTS = require('./../constants');
+var FLAGS = CONSTANTS.FLAGS;
+var LOG = require('./../../logger');
+var TYPES = CONSTANTS.TYPES;
+
+/**
+ * @param {Object} frame - The frame to be encoded as buffer
+ * @param {Number} frame.ttl Lease Time-To-Leave.
+ * @param {Number} frame.budget Number of requests granted.
+ * @param {String} [frame.metadata=null] The metadata.
+ *
+ * @returns {Buffer} The encoded error frame.
+ */
+module.exports = function getLeaseFrame(frame) {
+    assert.object(frame, 'frame');
+    assert.number(frame.ttl, 'frame.ttl');
+    assert.number(frame.budget, 'frame.budget');
+    assert.optionalString(frame.metadata, 'frame.metadata');
+    assert.string(frame.metadataEncoding, 'frame.metadataEncoding');
+
+    LOG.debug({frame: frame}, 'getLeaseFrame: entering');
+
+    var flags = FLAGS.NONE;
+
+    if (frame.metadata) {
+        flags = flags | FLAGS.METADATA;
+    }
+
+    var frameHeaderBuf = getFrameHeader({
+        length: 2 * 4 + frame.metadata.length,
+        type: TYPES.LEASE,
+        flags: flags,
+        streamId: 0
+    });
+
+    var leaseBuffer = new Buffer( 2 * 4 ).fill(0);
+    leaseBuffer.writeUInt32BE(frame.ttl, 0);
+    leaseBuffer.writeUInt32BE(frame.budget, 4);
+
+    var mdBuffer = new Buffer(frame.metadata, frame.metadataEncoding);
+
+    var buf = Buffer.concat([frameHeaderBuf, leaseBuffer, mdBuffer]);
+    LOG.debug({buffer: buf}, 'getLeaseFrame: exiting');
+    return buf;
+};

--- a/lib/protocol/frame/index.js
+++ b/lib/protocol/frame/index.js
@@ -4,6 +4,7 @@ module.exports = {
     encodePayload: require('./payload').encodePayload,
     decodePayload: require('./payload').decodePayload,
     getErrorFrame: require('./getErrorFrame'),
+    getLeaseFrame: require('./getLeaseFrame'),
     getFrameHeader: require('./getFrameHeader'),
     getReqResFrame: require('./getReqResFrame'),
     getResponseFrame: require('./getResponseFrame'),

--- a/lib/protocol/frame/parseFrame.js
+++ b/lib/protocol/frame/parseFrame.js
@@ -176,18 +176,18 @@ function parseErrorCode(buf, frame) {
     return frame;
 }
 
-function parseLeaseCode(buf, frame) {
-    frame.ttl = buf.buffer.readUInt32BE(12);
-    frame.budget = buf.buffer.readUInt32BE(16);
-    buf.offset += 8;
+function parseLeaseCode(b, frame) {
+    frame.ttl = b.buffer.readUInt32BE(12);
+    frame.budget = b.buffer.readUInt32BE(16);
+    b.offset += 8;
 
     var hasMetadata = frame.header.flags & CONSTANTS.FLAGS.METADATA;
 
     if (hasMetadata) {
-        var mdLength = buf.buffer.length - buf.offset;
-        frame.metadata = buf.buffer.slice(buf.offset, buf.offset + mdLength)
+        var mdLength = b.buffer.length - b.offset;
+        frame.metadata = b.buffer.slice(b.offset, b.offset + mdLength)
             .toString(frame.metadataEncoding);
-        buf.offset += mdLength;
+        b.offset += mdLength;
     }
 
     return frame;

--- a/lib/protocol/frame/parseFrame.js
+++ b/lib/protocol/frame/parseFrame.js
@@ -68,7 +68,7 @@ function parse(buf, dataEncoding, metadataEncoding, lengthOptional) {
             parseData(buffer, frame);
             break;
         case TYPES.LEASE:
-            parseLeaseCode(buffer, frame);
+            parseLeaseFrame(buffer, frame);
             break;
         case TYPES.RESPONSE:
             parseMetadata(buffer, frame);
@@ -176,7 +176,7 @@ function parseErrorCode(buf, frame) {
     return frame;
 }
 
-function parseLeaseCode(b, frame) {
+function parseLeaseFrame(b, frame) {
     frame.ttl = b.buffer.readUInt32BE(12);
     frame.budget = b.buffer.readUInt32BE(16);
     b.offset += 8;

--- a/lib/protocol/frame/parseFrame.js
+++ b/lib/protocol/frame/parseFrame.js
@@ -67,6 +67,9 @@ function parse(buf, dataEncoding, metadataEncoding, lengthOptional) {
             parseMetadata(buffer, frame);
             parseData(buffer, frame);
             break;
+        case TYPES.LEASE:
+            parseLeaseCode(buffer, frame);
+            break;
         case TYPES.RESPONSE:
             parseMetadata(buffer, frame);
             parseData(buffer, frame);
@@ -170,6 +173,23 @@ function parseErrorCode(buf, frame) {
     }
     frame.errorCode = code;
     buf.offset += 4;
+    return frame;
+}
+
+function parseLeaseCode(buf, frame) {
+    frame.ttl = buf.buffer.readUInt32BE(12);
+    frame.budget = buf.buffer.readUInt32BE(16);
+    buf.offset += 8;
+
+    var hasMetadata = frame.header.flags & CONSTANTS.FLAGS.METADATA;
+
+    if (hasMetadata) {
+        var mdLength = buf.buffer.length - buf.offset;
+        frame.metadata = buf.buffer.slice(buf.offset, buf.offset + mdLength)
+            .toString(frame.metadataEncoding);
+        buf.offset += mdLength;
+    }
+
     return frame;
 }
 

--- a/test/frame/frame.test.js
+++ b/test/frame/frame.test.js
@@ -124,6 +124,28 @@ describe('setup', function () {
     });
 });
 
+describe('lease', function () {
+    it('encode/decode', function () {
+        var seedFrame = {
+            ttl: getRandomInt(0, Math.pow(2, 32)),
+            budget: getRandomInt(0, Math.pow(2, 32)),
+            metadata: 'What have we found',
+            metadataEncoding: METADATA_ENCODING
+        };
+
+        var leaseFrame = frame.getLeaseFrame(seedFrame);
+        var actualFrame = frame.parseFrame(leaseFrame);
+        assert.isObject(actualFrame.header);
+        assert.equal(actualFrame.header.streamId, 0);
+        assert.equal(actualFrame.header.type, CONSTANTS.TYPES.LEASE);
+        assert.equal(actualFrame.header.flags, CONSTANTS.FLAGS.METADATA);
+        assert.equal(actualFrame.ttl, seedFrame.ttl);
+        assert.equal(actualFrame.budget, seedFrame.budget);
+        assert.equal(actualFrame.metadata.toString(), seedFrame.metadata);
+    });
+});
+
+
 describe('error', function () {
     it('encode/decode', function () {
         var seedFrame = {


### PR DESCRIPTION
Currently, reactivesocket-js doesn't support `LEASE`.
If a client enable the `LEASE` flag during the setup, it will not be
able to parse the `LEASE` frames periodically sent by the server.

Even though nothing is done with the lease, it can still allow a client
to enable it, which can let the server enabling rejection of request when
it is over capacity.