### PR TITLE
Introduce `close` method and cancel timers on 'close'.

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -114,7 +114,7 @@ function Connection(opts) {
     this._transportStream = opts.transport.stream;
 
     var transportStreamErr;
-    self._transportStream.once('close', function close() {
+    self._transportStream.once('close', function onClose() {
         self.emit('close');
         self._log.info('rs-connection: transport closed, emitting error to ' +
                        'all active streams');
@@ -134,25 +134,29 @@ function Connection(opts) {
             stream.setError(transportStreamErr ||
                             new Error('transport connection closed'));
         });
+        // cancel all running timers
+        self.timers.forEach(function (timer) {
+            clearInterval(timer);
+        }, this);
     });
 
-    self._transportStream.on('error', function error(err) {
+    self._transportStream.on('error', function onTransportError(err) {
         self._log.error({err: err}, 'rs-connection: got transport error');
         self.emit('error', err);
         transportStreamErr = err;
     });
 
-    self._pStream.on('error', function error(err) {
+    self._pStream.on('error', function onParseError(err) {
         self._log.error({err: err}, 'rs-connection: got parse error');
         self.emit('error', err);
     });
-    self._sStream.on('error', function error(err) {
+    self._sStream.on('error', function onSerializeError(err) {
         self._log.error({err: err}, 'rs-connection: got serialize error');
         self.emit('error', err);
     });
 
     // Mux between different frame types
-    self._pStream.on('data', function read(frame) {
+    self._pStream.on('data', function onRead(frame) {
         self._log.debug({frame: frame}, 'rsClient.gotFrame');
 
         switch (frame.header.type) {
@@ -198,7 +202,7 @@ function Connection(opts) {
 
     if (opts.transport.framed) {
         this._framingStream = new FramingStream({log: self._log});
-        self._framingStream.on('error', function (err) {
+        self._framingStream.on('error', function onFramingError(err) {
             self._log.error({err: err}, 'rs-connection: got framing error');
             self.emit('error', err);
         });
@@ -207,6 +211,9 @@ function Connection(opts) {
     } else {
         self._transportStream.pipe(self._pStream);
     }
+
+    // array of timers used by periodic tasks
+    self.timers = [];
 
     // send setup frame if client
     if (self._type === 'server') {
@@ -238,9 +245,10 @@ function Connection(opts) {
             });
         });
 
-        setInterval(function keepaliveTicker () {
+        var ticker = setInterval(function keepaliveTicker () {
             self._getStream(0).keepalive(true);
         }, self._keepalive);
+        self.timers.push(ticker);
     }
 }
 util.inherits(Connection, EventEmitter);
@@ -354,6 +362,18 @@ Connection.prototype.availability = function availability() {
 };
 
 
+/**
+ * Close the ReactiveSocket, which close the underlying Transport (e.g. TCP).
+ *
+ * @returns {null}
+ */
+Connection.prototype.close = function close() {
+    var self = this;
+    self._log.debug('Connection.close: executing ');
+    self._transportStream.end();
+};
+
+
 /// Frame handlers
 
 
@@ -378,9 +398,10 @@ Connection.prototype._handleSetup = function _handleSetup(frame) {
         // of 2^30 requests per 5 seconds
         var budget = 1 << 30;
         self._getStream(0).sendLease(budget, 1000);
-        setInterval(function leaseTicker() {
+        var ticker = setInterval(function leaseTicker() {
             self._getStream(0).sendLease(budget, 1000);
         }, 5000);
+        self.timers.push(ticker);
     }
 
     // TODO: validate setup frame -- return setup_error on bad frame.

--- a/lib/connection/tcpConnection.js
+++ b/lib/connection/tcpConnection.js
@@ -126,7 +126,7 @@ TcpConnection.prototype.close = function close() {
         self.emit('close');
     });
 
-    self._tcpConn.end();
+    self._rsConnection.close();
 };
 
 /**

--- a/test/connection/lease.test.js
+++ b/test/connection/lease.test.js
@@ -83,4 +83,38 @@ describe('Lease test', function () {
             });
         });
     });
+
+    it('close() stops running timers (keepalive, lease, ...)', function (done) {
+        TCP_CLIENT_STREAM = net.connect(PORT, HOST, function (e) {
+            if (e) {
+                throw e;
+            }
+
+            TCP_CLIENT = reactiveSocket.createConnection({
+                log: LOG,
+                transport: {
+                    stream: TCP_CLIENT_STREAM,
+                    framed: true
+                },
+                lease: true,
+                keepalive: 50,
+                type: 'client',
+                metadataEncoding: 'utf-8',
+                dataEncoding: 'utf-8'
+            });
+
+            TCP_CLIENT.on('ready', function () {
+                TCP_CLIENT.close();
+                var keepaliveSeen = 0;
+                TCP_CLIENT.on('keepalive', function () {
+                    keepaliveSeen++;
+                });
+                setTimeout(function () {
+                    assert.equal(keepaliveSeen, 0,
+                        "Keepalive timer wasn't properly stopped!");
+                    done();
+                }, 1000);
+            });
+        });
+    });
 });


### PR DESCRIPTION
Currently, the two `setInterval` functions keep a reference to the `Connection`
object even though this object can be unreferenced. This constitutes a memory
leak since this (infinite) timer will always reference the ReactiveSocket.

I now keep an array of timers, which are canceled during `close`. I also
introduce a `close` method, responsible for closing the underlying transport.

Note, for readability, I also proposed to rename all eventHandler with the same
'onSomething' pattern.