### PR TITLE
Introduce timeout on the `Connection`

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,38 @@ websocket.on('open', function() {
 });
 ```
 
+## Timeout
+
+As a convenience for the user, the ReactiveSocket client provide 'timeout'
+events.
+Below is an example of how to listen to those events.
+
+```javascript
+var socket = ...;
+var client = reactiveSocket.createConnection({
+    log: LOG,
+    transport: {
+        stream: socket,
+        framed: true
+    },
+    requestTimeoutMs: 100,
+    type: 'client',
+    metadataEncoding: 'utf-8',
+    dataEncoding: 'utf-8'
+});
+
+client.on('ready', function () {
+    var responseStream = CLIENT_CON.request({data: 'request-data'});
+
+    responseStream.once('response', function (res) {
+        console.log('Yeah, a response ' + res.getResponse());
+    });
+    responseStream.once('timeout', function () {
+        console.log('Too late ');
+    });
+});
+```
+
 ## Lease Semantic
 
 ReactiveSocket client allows you to specify if you want to honor the lease

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -137,17 +137,14 @@ function Connection(opts) {
                             new Error('transport connection closed'));
         });
         // cancel all running timers
-        self.timers.forEach(function (timer) {
+        self._timers.forEach(function (timer) {
             clearInterval(timer);
         });
 
-        for (var id in self.requestTimers) {
-            if (!self.requestTimers.hasOwnProperty(id)) {
-                continue;
-            }
+        _.keys(self._requestTimers, function (id) {
             var timer = self.requestTimers[id];
             clearInterval(timer);
-        }
+        });
     });
 
     self._transportStream.on('error', function onTransportError(err) {
@@ -225,9 +222,9 @@ function Connection(opts) {
     }
 
     // array of timers used by periodic tasks
-    self.timers = [];
+    this._timers = [];
     // streamId-indexed array of timers used by requests timeout
-    self.requestTimers = {};
+    this._requestTimers = {};
 
     // send setup frame if client
     if (self._type === 'server') {
@@ -262,7 +259,7 @@ function Connection(opts) {
         var ticker = setInterval(function keepaliveTicker () {
             self._sendKeepalive(true);
         }, self._keepalive);
-        self.timers.push(ticker);
+        self._timers.push(ticker);
     }
 }
 util.inherits(Connection, EventEmitter);
@@ -299,12 +296,11 @@ Connection.prototype.request = function request(req) {
 
     var timer = setTimeout(function onRequestTimeout() {
         stream.removeAllListeners('response');
-        stream.cancel();
+        stream.cancel(null);
         self._deleteStream(streamId);
-        delete self.requestTimers[streamId];
         stream.emit('timeout', req);
     }, self._requestTimeoutMs);
-    self.requestTimers[streamId] = timer;
+    self._requestTimers[streamId] = timer;
 
     return stream;
 };
@@ -368,7 +364,7 @@ Connection.prototype.send = function send(frame, cb) {
 };
 
 /**
- * Send an lease frame
+ * Send a lease frame
  * @param {Number} numberOfRequest the number of request the client is allowed
  * to send.
  * @param {Number} ttl the duration of the lease validity in millisecond.
@@ -446,7 +442,7 @@ Connection.prototype._handleSetup = function _handleSetup(frame) {
         var ticker = setInterval(function leaseTicker() {
             self.sendLease(budget, 1000);
         }, 5000);
-        self.timers.push(ticker);
+        self._timers.push(ticker);
     }
 
     // TODO: validate setup frame -- return setup_error on bad frame.
@@ -552,7 +548,8 @@ Connection.prototype._handleCancel = function _handleCancel(frame) {
 // Send a Keepalive frame.
 Connection.prototype._sendKeepalive = function _sendKeepalive(requireResponse) {
     var self = this;
-    self._log.debug('Connection.keepalive: entering');
+    self._log.debug({requireResponse: requireResponse},
+        'Connection.keepalive: entering');
 
     var frame = {
         type: TYPES.KEEPALIVE,
@@ -614,5 +611,6 @@ Connection.prototype._deleteStream = function _deleteStream(id, noError) {
         self.emit('error', new Error('Deleting non-existent stream id ' + id));
     }
 
+    delete self._requestTimers[id];
     delete self._streams.streams[id];
 };

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -114,7 +114,7 @@ function Connection(opts) {
     this._transportStream = opts.transport.stream;
 
     var transportStreamErr;
-    self._transportStream.once('close', function close() {
+    self._transportStream.once('close', function onClose() {
         self.emit('close');
         self._log.info('rs-connection: transport closed, emitting error to ' +
                        'all active streams');
@@ -134,25 +134,29 @@ function Connection(opts) {
             stream.setError(transportStreamErr ||
                             new Error('transport connection closed'));
         });
+        // cancel all running timers
+        self.timers.forEach(function (timer) {
+            clearInterval(timer);
+        }, this);
     });
 
-    self._transportStream.on('error', function error(err) {
+    self._transportStream.on('error', function onTransportError(err) {
         self._log.error({err: err}, 'rs-connection: got transport error');
         self.emit('error', err);
         transportStreamErr = err;
     });
 
-    self._pStream.on('error', function error(err) {
+    self._pStream.on('error', function onParseError(err) {
         self._log.error({err: err}, 'rs-connection: got parse error');
         self.emit('error', err);
     });
-    self._sStream.on('error', function error(err) {
+    self._sStream.on('error', function onSerializeError(err) {
         self._log.error({err: err}, 'rs-connection: got serialize error');
         self.emit('error', err);
     });
 
     // Mux between different frame types
-    self._pStream.on('data', function read(frame) {
+    self._pStream.on('data', function onRead(frame) {
         self._log.debug({frame: frame}, 'rsClient.gotFrame');
 
         switch (frame.header.type) {
@@ -198,7 +202,7 @@ function Connection(opts) {
 
     if (opts.transport.framed) {
         this._framingStream = new FramingStream({log: self._log});
-        self._framingStream.on('error', function (err) {
+        self._framingStream.on('error', function onFramingError(err) {
             self._log.error({err: err}, 'rs-connection: got framing error');
             self.emit('error', err);
         });
@@ -207,6 +211,9 @@ function Connection(opts) {
     } else {
         self._transportStream.pipe(self._pStream);
     }
+
+    // array of timers used by periodic tasks
+    self.timers = [];
 
     // send setup frame if client
     if (self._type === 'server') {
@@ -238,9 +245,10 @@ function Connection(opts) {
             });
         });
 
-        setInterval(function keepaliveTicker () {
+        var ticker = setInterval(function keepaliveTicker () {
             self._getStream(0).keepalive(true);
         }, self._keepalive);
+        self.timers.push(ticker);
     }
 }
 util.inherits(Connection, EventEmitter);
@@ -354,6 +362,18 @@ Connection.prototype.availability = function availability() {
 };
 
 
+/**
+ * Close the ReactiveSocket, which close the underlying Transport (e.g. TCP).
+ *
+ * @returns {null}
+ */
+Connection.prototype.close = function close() {
+    var self = this;
+    self._log.debug('Connection.close: executing ');
+    self._transportStream.end();
+};
+
+
 /// Frame handlers
 
 
@@ -378,9 +398,10 @@ Connection.prototype._handleSetup = function _handleSetup(frame) {
         // of 2^30 requests per 5 seconds
         var budget = 1 << 30;
         self._getStream(0).sendLease(budget, 1000);
-        setInterval(function leaseTicker() {
+        var ticker = setInterval(function leaseTicker() {
             self._getStream(0).sendLease(budget, 1000);
         }, 5000);
+        self.timers.push(ticker);
     }
 
     // TODO: validate setup frame -- return setup_error on bad frame.

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -100,6 +100,8 @@ function Connection(opts) {
     this._maxLifetime = opts.maxLifetime || 10 * 1000;
     // maps a streamId from the server to a client interaction.
     this._streams = {
+        // as we add 2 to the latest streamId, this create id starting at 2
+        // for the client and 1 for the server.
         latest: self._type === 'client' ? 0 : -1,
         streams: {}
     };
@@ -138,11 +140,6 @@ function Connection(opts) {
         });
         // cancel all running timers
         self._timers.forEach(function (timer) {
-            clearInterval(timer);
-        });
-
-        _.keys(self._requestTimers, function (id) {
-            var timer = self.requestTimers[id];
             clearInterval(timer);
         });
     });
@@ -223,8 +220,6 @@ function Connection(opts) {
 
     // array of timers used by periodic tasks
     this._timers = [];
-    // streamId-indexed array of timers used by requests timeout
-    this._requestTimers = {};
 
     // send setup frame if client
     if (self._type === 'server') {
@@ -281,7 +276,7 @@ module.exports = Connection;
  */
 Connection.prototype.request = function request(req) {
     var self = this;
-    var stream = self._getNewStream();
+    var stream = self._getNewStream(self._requestTimeoutMs);
     var streamId = stream.getId();
     var frame = {
         type: TYPES.REQUEST_RESPONSE,
@@ -294,13 +289,9 @@ Connection.prototype.request = function request(req) {
     self._leaseNumberOfRequests = Math.max(0, self._leaseNumberOfRequests - 1);
     self.send(frame);
 
-    var timer = setTimeout(function onRequestTimeout() {
-        stream.removeAllListeners('response');
-        stream.cancel(null);
-        self._deleteStream(streamId);
-        stream.emit('timeout', req);
-    }, self._requestTimeoutMs);
-    self._requestTimers[streamId] = timer;
+    stream.on('timeout', function onTimeout () {
+        self._deleteStream(streamId, true);
+    });
 
     return stream;
 };
@@ -561,7 +552,7 @@ Connection.prototype._sendKeepalive = function _sendKeepalive(requireResponse) {
 };
 
 // Initiating streams will invoke this to get a new streamid.
-Connection.prototype._getNewStream = function _getNewStream() {
+Connection.prototype._getNewStream = function _getNewStream(timeoutMs) {
     var self = this;
     self._log.debug({latest_id: self._streams.latest},
                     'Connection._getNewStream: entering');
@@ -574,7 +565,8 @@ Connection.prototype._getNewStream = function _getNewStream() {
     var stream = new RSStream({
         connection: self,
         log: self._log,
-        id: id
+        id: id,
+        timeoutMs: timeoutMs
     });
 
     self._streams.latest += 2;
@@ -611,6 +603,5 @@ Connection.prototype._deleteStream = function _deleteStream(id, noError) {
         self.emit('error', new Error('Deleting non-existent stream id ' + id));
     }
 
-    delete self._requestTimers[id];
     delete self._streams.streams[id];
 };

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -30,6 +30,7 @@ var TYPES = CONSTANTS.TYPES;
  * @param {Boolean} opts.type Type of connection, one of 'client' or 'server'
  * @param {Number} [opts.keepalive=1000] Keep alive interval
  * @param {Number} [opts.maxLifetime=10000] maxLifetime interval.
+ * @param {Number} [opts.requestTimeoutMs=30000] request timeout in millisecond.
  * @param {String} [metadataEncoding=utf8] metadata encoding. Only set for
  * client conns.
  * @param {String} [dataEncoding=utf8] data encoding. Only set for client conns.
@@ -94,11 +95,12 @@ function Connection(opts) {
     this._keepalive = opts.keepalive || 1 * 1000;
     this._leaseNumberOfRequests = 0; // how many messages I'm allowed to send
     this._leaseExpirationDate = Date.now(); // date when the lease expire
+    this._requestTimeoutMs = opts.requestTimeoutMs || 30 * 1000;
     // TODO: we don't use this today
     this._maxLifetime = opts.maxLifetime || 10 * 1000;
     // maps a streamId from the server to a client interaction.
     this._streams = {
-        latest: 0,
+        latest: self._type === 'client' ? 0 : -1,
         streams: {}
     };
     this._sStream = new SerializeStream({
@@ -137,7 +139,15 @@ function Connection(opts) {
         // cancel all running timers
         self.timers.forEach(function (timer) {
             clearInterval(timer);
-        }, this);
+        });
+
+        for (var id in self.requestTimers) {
+            if (!self.requestTimers.hasOwnProperty(id)) {
+                continue;
+            }
+            var timer = self.requestTimers[id];
+            clearInterval(timer);
+        }
     });
 
     self._transportStream.on('error', function onTransportError(err) {
@@ -178,12 +188,14 @@ function Connection(opts) {
             case TYPES.KEEPALIVE:
                 self._handleKeepalive(frame);
                 break;
+            case TYPES.CANCEL:
+                self._handleCancel(frame);
+                break;
             case TYPES.REQUEST_FNF:
             case TYPES.REQUEST_STREAM:
             case TYPES.REQUEST_SUB:
             case TYPES.REQUEST_CHANNEL:
             case TYPES.REQUEST_N:
-            case TYPES.CANCEL:
             case TYPES.METADATA_PUSH:
             case TYPES.NEXT:
             case TYPES.COMPLETE:
@@ -214,6 +226,8 @@ function Connection(opts) {
 
     // array of timers used by periodic tasks
     self.timers = [];
+    // streamId-indexed array of timers used by requests timeout
+    self.requestTimers = {};
 
     // send setup frame if client
     if (self._type === 'server') {
@@ -246,7 +260,7 @@ function Connection(opts) {
         });
 
         var ticker = setInterval(function keepaliveTicker () {
-            self._getStream(0).keepalive(true);
+            self._sendKeepalive(true);
         }, self._keepalive);
         self.timers.push(ticker);
     }
@@ -271,16 +285,26 @@ module.exports = Connection;
 Connection.prototype.request = function request(req) {
     var self = this;
     var stream = self._getNewStream();
+    var streamId = stream.getId();
     var frame = {
         type: TYPES.REQUEST_RESPONSE,
         flags: req.follows ? FLAGS.FOLLOWS : FLAGS.NONE,
         data: req.data,
         metadata: req.metadata,
-        streamId: stream.getId()
+        streamId: streamId
     };
 
     self._leaseNumberOfRequests = Math.max(0, self._leaseNumberOfRequests - 1);
     self.send(frame);
+
+    var timer = setTimeout(function onRequestTimeout() {
+        stream.removeAllListeners('response');
+        stream.cancel();
+        self._deleteStream(streamId);
+        delete self.requestTimers[streamId];
+        stream.emit('timeout', req);
+    }, self._requestTimeoutMs);
+    self.requestTimers[streamId] = timer;
 
     return stream;
 };
@@ -343,6 +367,27 @@ Connection.prototype.send = function send(frame, cb) {
     self._sStream.write(frame, cb);
 };
 
+/**
+ * Send an lease frame
+ * @param {Number} numberOfRequest the number of request the client is allowed
+ * to send.
+ * @param {Number} ttl the duration of the lease validity in millisecond.
+ *
+ * @returns {null}
+ */
+Connection.prototype.sendLease = function send(numberOfRequest, ttl) {
+    var self = this;
+    self._log.debug({numberOfRequest: numberOfRequest, ttl: ttl},
+        'Connection.sendLease: entering');
+
+    var frame = {
+        type: TYPES.LEASE,
+        budget: numberOfRequest,
+        ttl: ttl
+    };
+
+    self.send(frame);
+};
 
 /**
  * Return the current availability.
@@ -397,9 +442,9 @@ Connection.prototype._handleSetup = function _handleSetup(frame) {
         // This dummy strategy, grant leases to every clients at a maximum rate
         // of 2^30 requests per 5 seconds
         var budget = 1 << 30;
-        self._getStream(0).sendLease(budget, 1000);
+        self.sendLease(budget, 1000);
         var ticker = setInterval(function leaseTicker() {
-            self._getStream(0).sendLease(budget, 1000);
+            self.sendLease(budget, 1000);
         }, 5000);
         self.timers.push(ticker);
     }
@@ -436,12 +481,10 @@ Connection.prototype._handleKeepalive = function _handleKeepalive(frame) {
     var self = this;
     self._log.debug({frame: frame}, 'Connection._handleKeepalive: entering');
 
-    var stream = self._getStream(0);
-
     self.emit('keepalive', frame);
 
     if (frame.response) {
-        stream.keepalive(false);
+        self._sendKeepalive(false);
     }
 };
 
@@ -455,9 +498,15 @@ Connection.prototype._handleRequest = function _handleRequest(frame) {
         return;
     }
 
-    var stream = self._getStream(frame.header.streamId);
+    var streamId = frame.header.streamId;
+    var stream = self._getStream(streamId);
+    stream.on('response', function () {
+        self._deleteStream(streamId, false);
+    });
+    stream.on('error', function () {
+        self._deleteStream(streamId, false);
+    });
     stream.setRequest(frame);
-    self._deleteStream(frame.header.streamId);
 };
 
 Connection.prototype._handleResponse = function _handleResponse(frame) {
@@ -487,26 +536,39 @@ Connection.prototype._handleError = function _handleError(frame) {
     self._deleteStream(frame.header.streamId);
 };
 
+Connection.prototype._handleCancel = function _handleCancel(frame) {
+    var self = this;
+    self._log.debug({frame: frame}, 'Connection._cancel: entering');
+
+    var stream = self._getStream(frame.header.streamId);
+
+    stream.setCancel(frame);
+    self._deleteStream(frame.header.streamId);
+};
+
 
 /// Privates
 
+// Send a Keepalive frame.
+Connection.prototype._sendKeepalive = function _sendKeepalive(requireResponse) {
+    var self = this;
+    self._log.debug('Connection.keepalive: entering');
+
+    var frame = {
+        type: TYPES.KEEPALIVE,
+        response: requireResponse,
+        data: '' // data is optional, empty for saving bandwidth
+    };
+
+    self.send(frame);
+};
 
 // Initiating streams will invoke this to get a new streamid.
 Connection.prototype._getNewStream = function _getNewStream() {
     var self = this;
     self._log.debug({latest_id: self._streams.latest},
                     'Connection._getNewStream: entering');
-    var id;
-
-    if (self._streams.latest === 0) {
-        if (self._type === 'client') {
-            id = 2;
-        } else {
-            id = 1;
-        }
-    } else {
-        id = self._streams.latest + 2;
-    }
+    var id = self._streams.latest + 2;
 
     if (id > CONSTANTS.MAX_STREAM_ID) {
         self._emit('error', new Error('Stream ID Exhaustion'));
@@ -543,10 +605,12 @@ Connection.prototype._getStream = function _getStream(id) {
 };
 
 // Delete a stream from the table.
-Connection.prototype._deleteStream = function _deleteStream(id) {
+// the noError is useful when tolerate race conditions (e.g. cancel received at
+// the same time as the response)
+Connection.prototype._deleteStream = function _deleteStream(id, noError) {
     var self = this;
 
-    if (!self._streams.streams[id]) {
+    if (!noError && !self._streams.streams[id]) {
         self.emit('error', new Error('Deleting non-existent stream id ' + id));
     }
 

--- a/lib/connection/stream.js
+++ b/lib/connection/stream.js
@@ -124,14 +124,14 @@ RSStream.prototype.error = function error(err) {
  *
  * @returns {null}
  */
-RSStream.prototype.cancel = function cancel() {
+RSStream.prototype.cancel = function cancel(metadata) {
     var self = this;
     self._log.debug('Stream.cancel: entering');
 
     var frame = {
         type: TYPES.CANCEL,
         streamId: self._id,
-        metadata: '' // metadata is optional
+        metadata: metadata
     };
 
     self._connection.send(frame);

--- a/lib/connection/stream.js
+++ b/lib/connection/stream.js
@@ -21,10 +21,12 @@ var TYPES = CONSTANTS.TYPES;
  * @param {Object} opts -
  * @param {Object} opts.connection The RS Connection.
  * @param {Object} [opts.log=bunyan] The Bunyan logger.
+ * @param {number} [opts.timeoutMs=null] The timeout value.
  * @param {number} opts.id The id of this stream.
  * @constructor
  *
  * @emits response When a response is received by this stream
+ * @emits timeout When a timeout occurs
  * @emits setup-error When an error is received by this stream
  * @emits connection-error When an error is received by this stream
  * @emits application-error When an error is received by this stream
@@ -39,6 +41,7 @@ function RSStream(opts) {
     assert.object(opts, 'opts');
     assert.object(opts.connection, 'opts.connection');
     assert.optionalObject(opts.log, 'opts.log');
+    assert.optionalNumber(opts.timeoutMs, 'opts.timeoutMs');
     assert.number(opts.id, 'opts.id');
 
     this._connection = opts.connection;
@@ -59,6 +62,17 @@ function RSStream(opts) {
         });
     } else {
         this._log = LOG;
+    }
+
+    this._expired = false;
+    var self = this;
+
+    if (opts.timeoutMs) {
+        this._timer = setInterval(function onTimeout() {
+            self._expired = true;
+            self.cancel('timeout');
+            self.emit('timeout', self);
+        }, opts.timeoutMs);
     }
 }
 util.inherits(RSStream, EventEmitter);
@@ -114,14 +128,13 @@ RSStream.prototype.error = function error(err) {
     };
 
     self._connection.send(frame);
-    self.emit('error', err);
 };
 
 /**
  * Cancel the present stream.
  * This will send a Cancel frame to the server and ignore any subsequent
  * responses we may receive.
- *
+ * @param {String} [metadata=null] The optional cause of the cancellation.
  * @returns {null}
  */
 RSStream.prototype.cancel = function cancel(metadata) {
@@ -174,6 +187,11 @@ RSStream.prototype.getError = function getError() {
 RSStream.prototype.setResponse = function setResponse(frame) {
     var self = this;
     var response = self._data.response;
+
+    if (self._expired) {
+        return;
+    }
+    clearTimeout(self._timer);
 
     if (!response) {
         response = {};
@@ -250,6 +268,11 @@ RSStream.prototype.setRequest = function setRequest(frame) {
  */
 RSStream.prototype.setError = function setError(frame) {
     var self = this;
+
+    if (self._expired) {
+        return;
+    }
+    clearTimeout(self._timer);
 
     var error = _.pick(frame, 'errorCode', 'metadata', 'data');
     self._data.error = error;

--- a/lib/connection/stream.js
+++ b/lib/connection/stream.js
@@ -89,6 +89,7 @@ RSStream.prototype.response = function response(res) {
         streamId: self._id
     };
     self._connection.send(frame);
+    self.emit('response', res);
 };
 
 /**
@@ -113,47 +114,28 @@ RSStream.prototype.error = function error(err) {
     };
 
     self._connection.send(frame);
+    self.emit('error', err);
 };
 
 /**
- * Send an keepalive frame
- * @param {Bool} requireResponse require a response from the peer.
+ * Cancel the present stream.
+ * This will send a Cancel frame to the server and ignore any subsequent
+ * responses we may receive.
  *
  * @returns {null}
  */
-RSStream.prototype.keepalive = function keepalive(requireResponse) {
+RSStream.prototype.cancel = function cancel() {
     var self = this;
-    self._log.debug('Stream.keepalive: entering');
+    self._log.debug('Stream.cancel: entering');
 
     var frame = {
-        type: TYPES.KEEPALIVE,
-        response: requireResponse,
-        data: '' // data is optional, empty for saving bandwidth
+        type: TYPES.CANCEL,
+        streamId: self._id,
+        metadata: '' // metadata is optional
     };
 
     self._connection.send(frame);
 };
-
-/**
- * Send an lease frame
- * @param {Number} budget the amount of message the client is allowed to send.
- * @param {Number} ttl the duration of the lease validity in millisecond.
- *
- * @returns {null}
- */
-RSStream.prototype.sendLease = function sendLease(budget, ttl) {
-    var self = this;
-    self._log.debug('Stream.Lease: entering');
-
-    var frame = {
-        type: TYPES.LEASE,
-        budget: budget,
-        ttl: ttl
-    };
-
-    self._connection.send(frame);
-};
-
 
 /**
  * @returns {Object} The request object from this stream.
@@ -313,6 +295,17 @@ RSStream.prototype.setError = function setError(frame) {
             self.emit('error', error);
             break;
     }
+};
+
+/**
+ * Cancel the inbound request for this stream.
+ * @param {Object} frame The cancel frame.
+ *
+ * @returns {null}
+ */
+RSStream.prototype.setCancel = function setCancel(frame) {
+    var self = this;
+    self.emit('cancel', frame);
 };
 
 

--- a/lib/connection/tcpConnection.js
+++ b/lib/connection/tcpConnection.js
@@ -122,10 +122,9 @@ TcpConnection.prototype.close = function close() {
     self._log.debug('closing connection');
 
     self._tcpConn.removeListener('close', self._closeListener);
-    self._tcpConn.once('close', function () {
+    self._rsConnection.once('close', function onClose() {
         self.emit('close');
     });
-
     self._rsConnection.close();
 };
 

--- a/lib/connection/tcpConnection.js
+++ b/lib/connection/tcpConnection.js
@@ -126,7 +126,7 @@ TcpConnection.prototype.close = function close() {
         self.emit('close');
     });
 
-    self._tcpConn.end();
+    self._rsConnection.close();
 };
 
 /**

--- a/lib/protocol/frame/getCancelFrame.js
+++ b/lib/protocol/frame/getCancelFrame.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var assert = require('assert-plus');
+
+var getFrameHeader = require('./getFrameHeader');
+
+var CONSTANTS = require('./../constants');
+var FLAGS = CONSTANTS.FLAGS;
+var LOG = require('./../../logger');
+var TYPES = CONSTANTS.TYPES;
+
+/**
+ * @param {Object} frame - The frame to be encoded as buffer
+ * @param {Number} frame.streamId The stream ID.
+ * @param {String} [frame.metadata=null] The optional metadata associated with
+ * the cancel frame.
+ *
+ * @returns {Buffer} The encoded cancel frame.
+ */
+module.exports = function getCancelFrame(frame) {
+    assert.object(frame, 'frame');
+    assert.number(frame.streamId, 'frame.streamId');
+    assert.optionalString(frame.metadata, 'frame.metadata');
+    assert.optionalString(frame.metadataEncoding, 'frame.metadataEncoding');
+
+    LOG.debug({frame: frame}, 'getCancelFrame: entering');
+
+    var flags = FLAGS.NONE;
+    var mdLength = 0;
+
+    if (frame.metadata) {
+        flags = flags | FLAGS.METADATA;
+        mdLength = frame.metadata.length;
+    }
+
+    var frameHeaderBuf = getFrameHeader({
+        length: mdLength,
+        type: TYPES.CANCEL,
+        flags: flags,
+        streamId: frame.streamId
+    });
+
+    var metadataBuffer = new Buffer(frame.metadata, frame.metadataEncoding);
+
+    var buf = Buffer.concat([frameHeaderBuf, metadataBuffer]);
+    LOG.debug({buffer: buf}, 'getCancelFrame: exiting');
+    return buf;
+};

--- a/lib/protocol/frame/getCancelFrame.js
+++ b/lib/protocol/frame/getCancelFrame.js
@@ -29,6 +29,7 @@ module.exports = function getCancelFrame(frame) {
     var mdLength = 0;
 
     var metadataBuffer = new Buffer(0);
+
     if (frame.metadata) {
         flags = flags | FLAGS.METADATA;
         mdLength = frame.metadata.length;

--- a/lib/protocol/frame/getCancelFrame.js
+++ b/lib/protocol/frame/getCancelFrame.js
@@ -28,9 +28,11 @@ module.exports = function getCancelFrame(frame) {
     var flags = FLAGS.NONE;
     var mdLength = 0;
 
+    var metadataBuffer = new Buffer(0);
     if (frame.metadata) {
         flags = flags | FLAGS.METADATA;
         mdLength = frame.metadata.length;
+        metadataBuffer = new Buffer(frame.metadata, frame.metadataEncoding);
     }
 
     var frameHeaderBuf = getFrameHeader({
@@ -39,8 +41,6 @@ module.exports = function getCancelFrame(frame) {
         flags: flags,
         streamId: frame.streamId
     });
-
-    var metadataBuffer = new Buffer(frame.metadata, frame.metadataEncoding);
 
     var buf = Buffer.concat([frameHeaderBuf, metadataBuffer]);
     LOG.debug({buffer: buf}, 'getCancelFrame: exiting');

--- a/lib/protocol/frame/index.js
+++ b/lib/protocol/frame/index.js
@@ -6,6 +6,7 @@ module.exports = {
     getErrorFrame: require('./getErrorFrame'),
     getLeaseFrame: require('./getLeaseFrame'),
     getKeepaliveFrame: require('./getKeepaliveFrame'),
+    getCancelFrame: require('./getCancelFrame'),
     getFrameHeader: require('./getFrameHeader'),
     getReqResFrame: require('./getReqResFrame'),
     getResponseFrame: require('./getResponseFrame'),

--- a/lib/protocol/frame/parseFrame.js
+++ b/lib/protocol/frame/parseFrame.js
@@ -64,6 +64,9 @@ function parse(buf, dataEncoding, metadataEncoding, lengthOptional) {
         case TYPES.KEEPALIVE:
             parseKeepaliveFrame(buffer, frame);
             break;
+        case TYPES.CANCEL:
+            parseCancelFrame(buffer, frame);
+            break;
         case TYPES.RESPONSE:
             parseMetadata(buffer, frame);
             parseData(buffer, frame);
@@ -194,6 +197,19 @@ function parseKeepaliveFrame(b, frame) {
     var dataLength = b.buffer.length - b.offset;
     frame.data = b.buffer.slice(b.offset, b.offset + dataLength);
     b.offset += dataLength;
+
+    return frame;
+}
+
+function parseCancelFrame(b, frame) {
+    var hasMetadata = frame.header.flags & CONSTANTS.FLAGS.METADATA;
+
+    if (hasMetadata) {
+        var mdLength = b.buffer.length - b.offset;
+        frame.metadata = b.buffer.slice(b.offset, b.offset + mdLength)
+            .toString(frame.metadataEncoding);
+        b.offset += mdLength;
+    }
 
     return frame;
 }

--- a/lib/streams/serializeStream.js
+++ b/lib/streams/serializeStream.js
@@ -71,6 +71,9 @@ SerializeStream.prototype._transform = function _transform(f, enc, cb) {
         case CONSTANTS.TYPES.LEASE:
             buf = frame.getLeaseFrame(f);
             break;
+        case CONSTANTS.TYPES.CANCEL:
+            buf = frame.getCancelFrame(f);
+            break;
         case CONSTANTS.TYPES.ERROR:
             buf = frame.getErrorFrame(f);
             break;

--- a/test/common/getSemaphore.js
+++ b/test/common/getSemaphore.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * @param {Number} count the initial value of the semaphore
+ * @param {Object} doneFn the callback to execute when the semaphore reaches 0
+ * @returns {Object} The semaphore object, with a `latch` method.
+ */
+module.exports = function getSemaphore(count, doneFn) {
+    return (function () {
+        var c = count;
+        return {
+            latch: function () {
+                c--;
+
+                if (c === 0) {
+                    doneFn();
+                }
+            }
+        };
+    }());
+};

--- a/test/connection/framedConnection.test.js
+++ b/test/connection/framedConnection.test.js
@@ -493,6 +493,9 @@ describe('framed-connection connection errors', function () {
                     done();
                 }
             });
+            SERVER_CON.on('connection-error', function () {
+                // discard client diconnection event
+            });
         });
 
         TCP_SERVER.listen({

--- a/test/connection/framedConnection.test.js
+++ b/test/connection/framedConnection.test.js
@@ -432,9 +432,6 @@ describe('framed-connection', function () {
             assert.deepEqual(stream.getRequest(), EXPECTED_REQ);
             stream.error(_.cloneDeep(EXPECTED_APPLICATION_ERROR));
             setImmediate(function () {
-                // should only have the setup stream cached in the connection
-                assert.equal(Object.keys(SERVER_CON._streams.streams).length,
-                             1);
                 assert.isOk(SERVER_CON._streams.streams[0]);
             });
         });

--- a/test/connection/lease.test.js
+++ b/test/connection/lease.test.js
@@ -83,4 +83,38 @@ describe('Lease test', function () {
             });
         });
     });
+
+    it('close() stops running timers (keepalive, lease, ...)', function (done) {
+        TCP_CLIENT_STREAM = net.connect(PORT, HOST, function (e) {
+            if (e) {
+                throw e;
+            }
+
+            TCP_CLIENT = reactiveSocket.createConnection({
+                log: LOG,
+                transport: {
+                    stream: TCP_CLIENT_STREAM,
+                    framed: true
+                },
+                lease: true,
+                keepalive: 50,
+                type: 'client',
+                metadataEncoding: 'utf-8',
+                dataEncoding: 'utf-8'
+            });
+
+            TCP_CLIENT.on('ready', function () {
+                TCP_CLIENT.close();
+                var keepaliveSeen = 0;
+                TCP_CLIENT.on('keepalive', function () {
+                    keepaliveSeen++;
+                });
+                setTimeout(function () {
+                    assert.equal(keepaliveSeen, 0,
+                        "Keepalive timer wasn't properly stopped!");
+                    done();
+                }, 1000);
+            });
+        });
+    });
 });

--- a/test/connection/timeout.test.js
+++ b/test/connection/timeout.test.js
@@ -102,18 +102,14 @@ describe('Timeout tests', function () {
             });
         });
 
-        var timerCount0 = Object.keys(CLIENT_CON._requestTimers).length;
         var response = CLIENT_CON.request({data: 'request-data'});
-        var timerCount1 = Object.keys(CLIENT_CON._requestTimers).length;
-        assert.equal(timerCount1 - timerCount0, 1);
 
         response.once('response', function (res) {
             assert(false,
                 "I shouldn't receive that, it's too late, I cancelled it!");
         });
         response.once('timeout', function () {
-            var timerCount2 = Object.keys(CLIENT_CON._requestTimers).length;
-            assert.equal(timerCount2 - timerCount0, 0);
+            assert(response._expired);
             semaphore.latch();
         });
     });

--- a/test/connection/timeout.test.js
+++ b/test/connection/timeout.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+var net = require('net');
+var assert = require('chai').assert;
+var bunyan = require('bunyan');
+
+var reactiveSocket = require('../../lib');
+var getSemaphore = require('../common/getSemaphore');
+
+
+var PORT = process.env.PORT || 1337;
+var HOST = process.env.HOST || 'localhost';
+
+describe('Timeout tests', function () {
+
+    var LOG = bunyan.createLogger({
+        name: 'timeout tests',
+        level: process.env.LOG_LEVEL || bunyan.INFO,
+        serializers: bunyan.stdSerializers
+    });
+
+    LOG.addSerializers({
+        buffer: function (buf) {
+            return buf.toString();
+        }
+    });
+
+
+    var TCP_SERVER;
+    var TCP_CLIENT_STREAM;
+
+    var SERVER_CON;
+    var CLIENT_CON;
+
+    beforeEach(function (done) {
+        var count = 0;
+        TCP_SERVER = net.createServer(function (con) {
+            SERVER_CON = reactiveSocket.createConnection({
+                log: LOG,
+                transport: {
+                    stream: con,
+                    framed: true
+                },
+                type: 'server'
+            });
+            SERVER_CON.on('ready', function () {
+                count++;
+
+                if (count === 2) {
+                    done();
+                }
+            });
+        });
+
+        TCP_SERVER.listen({
+            port: PORT,
+            host: HOST
+        }, function (err) {
+            if (err) {
+                throw err;
+            }
+
+            TCP_CLIENT_STREAM = net.connect(PORT, HOST, function (e) {
+                if (e) {
+                    throw e;
+                }
+                CLIENT_CON = reactiveSocket.createConnection({
+                    log: LOG,
+                    transport: {
+                        stream: TCP_CLIENT_STREAM,
+                        framed: true
+                    },
+                    requestTimeoutMs: 100,
+                    type: 'client',
+                    metadataEncoding: 'utf-8',
+                    dataEncoding: 'utf-8'
+                });
+
+                CLIENT_CON.on('ready', function () {
+                    count++;
+
+                    if (count === 2) {
+                        done();
+                    }
+                });
+            });
+        });
+    });
+
+    afterEach(function (done) {
+        CLIENT_CON.close();
+        TCP_SERVER.close(done);
+    });
+
+    it('should cancel latent request', function (done) {
+        var semaphore = getSemaphore(2, done);
+
+        SERVER_CON.once('request', function (stream) {
+            // The server never responds to the request
+            stream.once('cancel', function () {
+                semaphore.latch();
+            });
+        });
+
+        var timerCount0 = Object.keys(CLIENT_CON.requestTimers).length;
+        var response = CLIENT_CON.request({data: 'request-data'});
+        var timerCount1 = Object.keys(CLIENT_CON.requestTimers).length;
+        assert.equal(timerCount1 - timerCount0, 1);
+
+        response.once('response', function (res) {
+            assert(false,
+                "I shouldn't receive that, it's too late, I cancelled it!");
+        });
+        response.once('timeout', function () {
+            var timerCount2 = Object.keys(CLIENT_CON.requestTimers).length;
+            assert.equal(timerCount2 - timerCount0, 0);
+            semaphore.latch();
+        });
+    });
+});

--- a/test/connection/timeout.test.js
+++ b/test/connection/timeout.test.js
@@ -102,9 +102,9 @@ describe('Timeout tests', function () {
             });
         });
 
-        var timerCount0 = Object.keys(CLIENT_CON.requestTimers).length;
+        var timerCount0 = Object.keys(CLIENT_CON._requestTimers).length;
         var response = CLIENT_CON.request({data: 'request-data'});
-        var timerCount1 = Object.keys(CLIENT_CON.requestTimers).length;
+        var timerCount1 = Object.keys(CLIENT_CON._requestTimers).length;
         assert.equal(timerCount1 - timerCount0, 1);
 
         response.once('response', function (res) {
@@ -112,7 +112,7 @@ describe('Timeout tests', function () {
                 "I shouldn't receive that, it's too late, I cancelled it!");
         });
         response.once('timeout', function () {
-            var timerCount2 = Object.keys(CLIENT_CON.requestTimers).length;
+            var timerCount2 = Object.keys(CLIENT_CON._requestTimers).length;
             assert.equal(timerCount2 - timerCount0, 0);
             semaphore.latch();
         });

--- a/test/frame/frame.test.js
+++ b/test/frame/frame.test.js
@@ -131,7 +131,7 @@ describe('error', function () {
     it('encode/decode', function () {
         var seedFrame = {
             streamId: getRandomInt(0, Math.pow(2, 32)),
-            errorCode: getRandomInt(0, Math.pow(2, 16)),
+            errorCode: getRandomInt(0, Math.pow(2, 32)),
             data: 'Running over the same old ground',
             metadata: 'What have we found',
             metadataEncoding: METADATA_ENCODING,
@@ -185,6 +185,24 @@ describe('keepalive', function () {
         assert.equal(actualFrame.header.type, CONSTANTS.TYPES.KEEPALIVE);
         assert.equal(actualFrame.response, seedFrame.response);
         assert.equal(actualFrame.data.toString(), seedFrame.data);
+    });
+});
+
+describe('cancel', function () {
+    it('encode/decode', function () {
+        var seedFrame = {
+            streamId: getRandomInt(0, Math.pow(2, 32)),
+            metadata: "I don't want it anymore!",
+            metadataEncoding: DATA_ENCODING
+        };
+
+        var cancelFrame = frame.getCancelFrame(seedFrame);
+        var actualFrame = frame.parseFrame(cancelFrame);
+        assert.isObject(actualFrame.header);
+        assert.equal(actualFrame.header.streamId, seedFrame.streamId);
+        assert.equal(actualFrame.header.type, CONSTANTS.TYPES.CANCEL);
+        assert.equal(actualFrame.response, seedFrame.response);
+        assert.equal(actualFrame.metadata.toString(), seedFrame.metadata);
     });
 });
 


### PR DESCRIPTION
***Problem***
Currently there's no notion of timeout, messages sent to a blackhole will never
trigger any events on the client side.

***Solution***
I implemented a new message `CANCEL`, which is send after `requestTimeoutMs`
to the server. The client stream will receive a 'timeout' event.
This change force me to keep the stream object alive a little bit longer,
because now a server can receive another message, even after a `REQUEST`
(e.g. `CANCEL`). The stream is now deleted when either the server respond
or error.

***Modification***
I also moved the `keepalive` and `sendLease` methods from the stream to the connection.
Indeed, those methods must always be used at the connection level (on the stream 0), it
doesn't make sense to let them in the API of stream.