### PR TITLE
Load Balancer Connection fixes

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -6,7 +6,6 @@ var EventEmitter = require('events');
 
 var _ = require('lodash');
 var assert = require('assert-plus');
-var bunyan = require('bunyan');
 
 var FramingStream = require('../streams/framingStream');
 var ParseStream = require('../streams/parseStream');
@@ -79,8 +78,7 @@ function Connection(opts) {
 
     if (opts.log) {
         this._log = opts.log.child({
-            component: 'rs-connection',
-            level: process.env.LOG_LEVEL || bunyan.WARN
+            component: 'rs-connection'
         });
     } else {
         this._log = LOG;

--- a/lib/connection/stream.js
+++ b/lib/connection/stream.js
@@ -6,7 +6,6 @@ var EventEmitter = require('events');
 
 var _ = require('lodash');
 var assert = require('assert-plus');
-var bunyan = require('bunyan');
 
 var CONSTANTS = require('../protocol/constants');
 var ERROR_CODES = CONSTANTS.ERROR_CODES;
@@ -54,8 +53,7 @@ function RSStream(opts) {
 
     if (opts.log) {
         this._log = opts.log.child({
-            component: 'rs-stream',
-            level: process.env.LOG_LEVEL || bunyan.WARN
+            component: 'rs-stream'
         });
     } else {
         this._log = LOG;

--- a/lib/connection/tcpConnection.js
+++ b/lib/connection/tcpConnection.js
@@ -7,7 +7,6 @@ var EventEmitter = require('events');
 
 var _ = require('lodash');
 var assert = require('assert-plus');
-var bunyan = require('bunyan');
 
 var Connection = require('./connection');
 
@@ -42,8 +41,7 @@ function TcpConnection(opts) {
 
     if (opts.log) {
         this._log = opts.log.child({
-            component: 'rs-tcp-connection',
-            level: process.env.LOG_LEVEL || bunyan.WARN
+            component: 'rs-tcp-connection'
         });
     } else {
         this._log = LOG;

--- a/lib/connection/tcpLoadBalancer.js
+++ b/lib/connection/tcpLoadBalancer.js
@@ -102,7 +102,7 @@ function TcpLoadBalancer(opts) {
         var count = 0;
 
         for (var i = 0; i < self._size; i++) {
-            connect(function () {
+            self._connect(function () {
                 count++;
 
                 if (!self._ready) {
@@ -116,63 +116,6 @@ function TcpLoadBalancer(opts) {
                 }
             });
         }
-    }
-
-    // Randomly connect to a new server
-    function connect(cb) {
-        cb = _.once(cb);
-
-        var freeList = _.keys(self._connections.free);
-
-        if (freeList.length === 0) {
-            self._log.warn('TcpLoadBalancer.connect: no more free ' +
-                           'connections');
-            return cb();
-        }
-
-        var connOpts = _.sample(self._connections.free);
-        var connStr = connOpts.host + ':' + connOpts.port;
-        self._log.info({connOpts: connOpts},
-                       'TcpLoadBalancer.connect: entering');
-
-        // remove the connection from the free list so we don't pick it again
-        // for the next connection
-        delete self._connections.free[connStr];
-        self._connections.connecting[connStr] = new TcpConnection({
-            connOpts: connOpts,
-            rsOpts: self._rsOpts,
-            log: self._log
-        });
-
-        self._connections.connecting[connStr].once('ready', function () {
-            self._log.debug({connOpts: connOpts},
-                            'TcpLoadBalancer: connection ready');
-            self._connections.connected[connStr] =
-                self._connections.connecting[connStr];
-            delete self._connections.connecting[connStr];
-
-            self.emit('connect', self._connections.connected[connStr]);
-            return cb(null, connStr);
-        });
-
-        // on connection close we pick a new connection to connect to.
-        self._connections.connecting[connStr].once('close', function () {
-            self._log.info({connOpts: connOpts},
-                           'TcpLoadBalancer: connection closed');
-            delete self._connections.connecting[connStr];
-            delete self._connections.connected[connStr];
-            // don't reconnect if the pool is closed
-            if (self._closed) {
-                if (_.keys(self._connections.connecting).length === 0 &&
-                    _.keys(self._connections.connected).length === 0) {
-                    self.emit('close');
-                }
-                return;
-            }
-            connect(cb);
-        });
-
-        return null;
     }
 
     // random pick a connected server
@@ -256,4 +199,67 @@ TcpLoadBalancer.prototype.updateHosts = function updateHosts(hosts) {
             self._connections.connected[connStr].close();
         }
     });
+};
+
+
+/// Privates
+
+
+// Randomly connect to a new server
+TcpLoadBalancer.prototype._connect = function _connect(cb) {
+    var self = this;
+
+    self._log.info('TcpLoadBalancer.connect: enteringt');
+
+    cb = _.once(cb);
+
+    if (_.keys(self._connections.free).length === 0) {
+        self._log.warn('TcpLoadBalancer.connect: no more free ' +
+                       'connections');
+        return cb();
+    }
+
+    var connOpts = _.sample(self._connections.free);
+    var connStr = connOpts.host + ':' + connOpts.port;
+    self._log.info({connOpts: connOpts},
+                   'TcpLoadBalancer.connect: entering');
+
+    // remove the connection from the free list so we don't pick it again
+    // for the next connection
+    delete self._connections.free[connStr];
+    self._connections.connecting[connStr] = new TcpConnection({
+        connOpts: connOpts,
+        rsOpts: self._rsOpts,
+        log: self._log
+    });
+
+    self._connections.connecting[connStr].once('ready', function () {
+        self._log.debug({connOpts: connOpts},
+                        'TcpLoadBalancer: connection ready');
+        self._connections.connected[connStr] =
+            self._connections.connecting[connStr];
+        delete self._connections.connecting[connStr];
+
+        self.emit('connect', self._connections.connected[connStr]);
+        return cb(null, connStr);
+    });
+
+    // on connection close we pick a new connection to connect to.
+    self._connections.connecting[connStr].once('close', function () {
+        self._log.info({connOpts: connOpts},
+                       'TcpLoadBalancer: connection closed');
+        delete self._connections.connecting[connStr];
+        delete self._connections.connected[connStr];
+        // don't reconnect if the pool is closed
+        if (self._closed) {
+            if (_.keys(self._connections.connecting).length === 0 &&
+                _.keys(self._connections.connected).length === 0) {
+                self.emit('close');
+            }
+            return;
+        }
+        self._connect(cb);
+    });
+
+    return null;
 };

--- a/lib/connection/tcpLoadBalancer.js
+++ b/lib/connection/tcpLoadBalancer.js
@@ -18,7 +18,7 @@ var LOG = require('../logger');
  * @param {Object} opts Options object
  * @param {Object} [opts.log=bunyan] Bunyan logger
  * @param {Array} opts.hosts The set of hosts of this connection pool.
- * @param {Number} [opts.size] The maximum number of connections to maintain in
+ * @param {Number} opts.size The maximum number of connections to maintain in
  * the pool.
  * @param {Object} [opts.rsOpts] The RS connection options, same options as
  * passed to new Connection();
@@ -37,7 +37,7 @@ function TcpLoadBalancer(opts) {
     EventEmitter.call(this);
     assert.object(opts, 'opts');
     assert.array(opts.hosts, 'opts.hosts');
-    assert.optionalNumber(opts.size, 'opts.size');
+    assert.number(opts.size, 'opts.size');
     assert.optionalObject(opts.log, 'opts.log');
     assert.optionalFunc(opts.strategy, 'opts.strategy');
 
@@ -56,12 +56,10 @@ function TcpLoadBalancer(opts) {
 
     self._log.debug({opts: opts}, 'rs.Pool: new');
 
-    this._size = opts.size || 3;
+    this._size = opts.size;
 
-    var numHosts = _.keys(opts.hosts).length;
-
-    if (numHosts < self._size) {
-        self._size = numHosts;
+    if (self._size <= 0) {
+        throw new Error('opts.size must be greater than 0');
     }
 
     this._ready = false;
@@ -105,14 +103,20 @@ function TcpLoadBalancer(opts) {
             self._connect(function () {
                 count++;
 
+                // TODO: these currently lie -- if there are no hosts to
+                // connect to, we will still emit both ready and connected
                 if (!self._ready) {
                     self._ready = true;
-                    self.emit('ready');
+                    setImmediate(function () {
+                        self.emit('ready');
+                    });
                 }
 
                 if (count === self._size) {
                     // all connections connected
-                    self.emit('connected');
+                    setImmediate(function () {
+                        self.emit('connected');
+                    });
                 }
             });
         }
@@ -166,7 +170,7 @@ TcpLoadBalancer.prototype.close = function close() {
 };
 
 /**
- * update the hosts in the free list, taking care to not duplicate any hosts
+ * Update the hosts in the free list, taking care to not duplicate any hosts
  * that are already in the connecting and connected states.  optionally
  * disconnect hosts that are no longer in the list
  * @param {array} hosts The set of updated hosts of this connection pool.
@@ -177,21 +181,24 @@ TcpLoadBalancer.prototype.updateHosts = function updateHosts(hosts) {
     var self = this;
     self._log.info({hosts: hosts}, 'TcpLoadBalancer.updateHosts: entering');
 
-    // hosts that don't currently exist in the pool
-    var newHosts = _.difference(hosts, self._hosts);
+    // add hosts that don't currently exist in the pool
+    var newHosts = _.differenceWith(hosts, self._hosts, _.isEqual);
     _.forEach(newHosts, function (h) {
         var connStr = h.host + ':' + h.port;
         self._connections.free[connStr] = h;
     });
-    // hosts that need to be removed
+
+    // delete hosts that are no longer in discovery
     var deadHosts = _.differenceWith(self._hosts, hosts, _.isEqual);
-
-    self._hosts = _.cloneDeep(hosts);
-
-    // close connections no longer in the host list
     _.forEach(deadHosts, function (h) {
         var connStr = h.host + ':' + h.port;
         delete self._connections.free[connStr];
+    });
+
+    // close hosts that are no longer in discovery. This should automatically
+    // ensure that a new connection is made from the fresh free list.
+    _.forEach(deadHosts, function (h) {
+        var connStr = h.host + ':' + h.port;
 
         if (self._connections.connecting[connStr]) {
             self._connections.connecting[connStr].close();
@@ -199,6 +206,30 @@ TcpLoadBalancer.prototype.updateHosts = function updateHosts(hosts) {
             self._connections.connected[connStr].close();
         }
     });
+
+    // update host list
+    self._hosts = _.cloneDeep(hosts);
+
+    // Now we check to see if we should create more connections. This is
+    // because conenctions could be < pool size, due to not having enough free
+    // hosts the last time updateHosts was invoked. If we now have more free
+    // hosts, then we should attempt to max out the configured pool size.
+    var activeConnCount = self._getActiveConnCount();
+    var additionalConnCount = self._size - activeConnCount;
+
+    if (additionalConnCount <= 0) {
+        return;
+    }
+    // we need to spawn the minimum of either freeCount or additionalConnCount
+    var freeCount = _.keys(self._connections.free).length;
+
+    if (freeCount < additionalConnCount) {
+        additionalConnCount = freeCount;
+    }
+
+    for (var i = 0; i < freeCount; i++) {
+        self._connect();
+    }
 };
 
 
@@ -209,20 +240,36 @@ TcpLoadBalancer.prototype.updateHosts = function updateHosts(hosts) {
 TcpLoadBalancer.prototype._connect = function _connect(cb) {
     var self = this;
 
-    self._log.info('TcpLoadBalancer.connect: enteringt');
+    self._log.info('TcpLoadBalancer.connect: entering');
 
+    if (!cb) {
+        cb = function () {};
+    }
     cb = _.once(cb);
 
+    // only try and reconnect if there are less active connections than the max
+    // pool size
+    var currActiveConnCount = self._getActiveConnCount();
+
+    if (currActiveConnCount >= self._size) {
+        self._log.warn({
+            currActiveConnCount: currActiveConnCount,
+            poolSize: self._size
+        }, 'TcpLoadBalancer._connect: not creating new connection, there are' +
+            ' already enough connections');
+        return cb();
+    }
+
+    // bug here -- if we get more connections in the future but there are no
+    // current connections, then we won't be connecting to the maximum pool size
     if (_.keys(self._connections.free).length === 0) {
-        self._log.warn('TcpLoadBalancer.connect: no more free ' +
-                       'connections');
+        self._log.warn('TcpLoadBalancer._connect: no more free connections');
         return cb();
     }
 
     var connOpts = _.sample(self._connections.free);
     var connStr = connOpts.host + ':' + connOpts.port;
-    self._log.info({connOpts: connOpts},
-                   'TcpLoadBalancer.connect: entering');
+    self._log.info({connOpts: connOpts}, 'TcpLoadBalancer.connect: entering');
 
     // remove the connection from the free list so we don't pick it again
     // for the next connection
@@ -233,21 +280,10 @@ TcpLoadBalancer.prototype._connect = function _connect(cb) {
         log: self._log
     });
 
-    self._connections.connecting[connStr].once('ready', function () {
-        self._log.debug({connOpts: connOpts},
-                        'TcpLoadBalancer: connection ready');
-        self._connections.connected[connStr] =
-            self._connections.connecting[connStr];
-        delete self._connections.connecting[connStr];
-
-        self.emit('connect', self._connections.connected[connStr]);
-        return cb(null, connStr);
-    });
-
     // on connection close we pick a new connection to connect to.
     self._connections.connecting[connStr].once('close', function () {
         self._log.info({connOpts: connOpts},
-                       'TcpLoadBalancer: connection closed');
+                       'TcpLoadBalancer._connect: connection closed');
         delete self._connections.connecting[connStr];
         delete self._connections.connected[connStr];
         // don't reconnect if the pool is closed
@@ -258,8 +294,35 @@ TcpLoadBalancer.prototype._connect = function _connect(cb) {
             }
             return;
         }
-        self._connect(cb);
+        // only try and reconnect if we haven't exceeded the pool size.
+        if (self._getActiveConnCount() < self._size) {
+            self._connect(cb);
+        }
+    });
+
+    self._connections.connecting[connStr].once('ready', function () {
+        self._log.debug({connOpts: connOpts},
+                        'TcpLoadBalancer._connect: connection ready');
+        self._connections.connected[connStr] =
+            self._connections.connecting[connStr];
+        delete self._connections.connecting[connStr];
+
+        self.emit('connect', self._connections.connected[connStr]);
+        return cb(null, connStr);
     });
 
     return null;
+};
+
+// Return a count of the "active" connections in the pool. An "active"
+// connection is one that is either in a connected or connecting state
+TcpLoadBalancer.prototype._getActiveConnCount = function _getActiveConnCount() {
+    var self = this;
+
+    var activeConnCount = _.keys(self._connections.connected).length +
+        _.keys(self._connections.connecting).length;
+    self._log.debug({activeConnCount: activeConnCount},
+                    'TcpLoadBalancer._getActiveConnCount: returning');
+
+    return activeConnCount;
 };

--- a/lib/connection/tcpLoadBalancer.js
+++ b/lib/connection/tcpLoadBalancer.js
@@ -26,8 +26,12 @@ var LOG = require('../logger');
  * connection.
  *
  * @emits connect when a new connection is made.
- * @emits ready when there is at least one connection in the pool.
- * @emits connected when the pool is fully connected.
+ * @emits ready the first time there is a connected connection in the load
+ * balancer. This is emitted only once. Listen to this event if you'd like to
+ * start making requests as soon as there's an available connection.
+ * @emits connected the first time when there is a complete set of connected
+ * connections. This is only emitted once. Listen to this event if you'd like
+ * to start making requests as soon as the LB is full of connections.
  * @emits close when the pool is completely closed and devoid of any connected
  * connections.
  *
@@ -63,6 +67,7 @@ function TcpLoadBalancer(opts) {
     }
 
     this._ready = false;
+    this._connected = false;
 
     this._closed = false;
 
@@ -91,35 +96,11 @@ function TcpLoadBalancer(opts) {
     }, opts.rsOpts);
 
 
-    seedPool();
-
     this._strategy = opts.strategy || random;
 
     // seed the pool with connections
-    function seedPool (cb) {
-        var count = 0;
-
-        for (var i = 0; i < self._size; i++) {
-            self._connect(function () {
-                count++;
-
-                // TODO: these currently lie -- if there are no hosts to
-                // connect to, we will still emit both ready and connected
-                if (!self._ready) {
-                    self._ready = true;
-                    setImmediate(function () {
-                        self.emit('ready');
-                    });
-                }
-
-                if (count === self._size) {
-                    // all connections connected
-                    setImmediate(function () {
-                        self.emit('connected');
-                    });
-                }
-            });
-        }
+    for (var i = 0; i < self._size; i++) {
+        self._connect();
     }
 
     // random pick a connected server
@@ -257,14 +238,12 @@ TcpLoadBalancer.prototype._connect = function _connect(cb) {
             poolSize: self._size
         }, 'TcpLoadBalancer._connect: not creating new connection, there are' +
             ' already enough connections');
-        return cb();
+        return cb(new Error('not creating new connection'));
     }
 
-    // bug here -- if we get more connections in the future but there are no
-    // current connections, then we won't be connecting to the maximum pool size
     if (_.keys(self._connections.free).length === 0) {
         self._log.warn('TcpLoadBalancer._connect: no more free connections');
-        return cb();
+        return cb(new Error('no more free connections'));
     }
 
     var connOpts = _.sample(self._connections.free);
@@ -308,6 +287,26 @@ TcpLoadBalancer.prototype._connect = function _connect(cb) {
         delete self._connections.connecting[connStr];
 
         self.emit('connect', self._connections.connected[connStr]);
+        // if we haven't yet emitted a ready event, now's the time
+        if (!self._ready) {
+            self._ready = true;
+            setImmediate(function () {
+                self._log.info('TcpLoadBalancer._connect: pool ready');
+                self.emit('ready');
+            });
+        }
+        // emit connected if we have the maximum number of connected
+        // connections for the first time
+        if (!self._connected) {
+            if (_.keys(self._connections.connected).length === self._size) {
+                self._connected = true;
+                setImmediate(function () {
+                    self._log.info('TcpLoadBalancer._connect: pool connected');
+                    self.emit('connected');
+                });
+            }
+        }
+        self._log.info({connStr: connStr}, 'TcpLoadBalancer._connect: exiting');
         return cb(null, connStr);
     });
 
@@ -326,3 +325,4 @@ TcpLoadBalancer.prototype._getActiveConnCount = function _getActiveConnCount() {
 
     return activeConnCount;
 };
+

--- a/lib/connection/tcpLoadBalancer.js
+++ b/lib/connection/tcpLoadBalancer.js
@@ -192,7 +192,7 @@ TcpLoadBalancer.prototype.updateHosts = function updateHosts(hosts) {
     self._hosts = _.cloneDeep(hosts);
 
     // Now we check to see if we should create more connections. This is
-    // because conenctions could be < pool size, due to not having enough free
+    // because connections could be < pool size, due to not having enough free
     // hosts the last time updateHosts was invoked. If we now have more free
     // hosts, then we should attempt to max out the configured pool size.
     var activeConnCount = self._getActiveConnCount();
@@ -202,13 +202,10 @@ TcpLoadBalancer.prototype.updateHosts = function updateHosts(hosts) {
         return;
     }
     // we need to spawn the minimum of either freeCount or additionalConnCount
-    var freeCount = _.keys(self._connections.free).length;
+    additionalConnCount = Math.min(additionalConnCount,
+                                   _.keys(self._connections.free).length);
 
-    if (freeCount < additionalConnCount) {
-        additionalConnCount = freeCount;
-    }
-
-    for (var i = 0; i < freeCount; i++) {
+    for (var i = 0; i < additionalConnCount; i++) {
         self._connect();
     }
 };

--- a/test/common/log.js
+++ b/test/common/log.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var bunyan = require('bunyan');
+
+var LOG = bunyan.createLogger({
+    name: 'reactive socket tests',
+    level: process.env.LOG_LEVEL || bunyan.ERROR,
+    serializers: bunyan.stdSerializers,
+    stream: process.stderr
+});
+
+LOG.addSerializers({
+    buffer: function (buf) {
+        return buf.toString();
+    }
+});
+
+module.exports = LOG;

--- a/test/connection/framedConnection.test.js
+++ b/test/connection/framedConnection.test.js
@@ -5,11 +5,11 @@ var net = require('net');
 
 var _ = require('lodash');
 var assert = require('chai').assert;
-var bunyan = require('bunyan');
 
 var reactiveSocket = require('../../lib');
 
 var ERROR_CODES = reactiveSocket.ERROR_CODES;
+var LOG = require('../common/log');
 
 var PORT = process.env.PORT || 1337;
 var HOST = process.env.HOST || 'localhost';
@@ -37,19 +37,6 @@ var EXPECTED_APPLICATION_ERROR = {
 };
 
 describe('frame-connection-setup', function () {
-
-    var LOG = bunyan.createLogger({
-        name: 'framed connection setup tests',
-        level: process.env.LOG_LEVEL || bunyan.INFO,
-        serializers: bunyan.stdSerializers
-    });
-
-    LOG.addSerializers({
-        buffer: function (buf) {
-            return buf.toString();
-        }
-    });
-
     var TCP_SERVER;
     var TCP_CLIENT_STREAMS = [];
 
@@ -164,17 +151,6 @@ describe('frame-connection-setup', function () {
 });
 
 describe('framed-connection-keepalive', function () {
-    var LOG = bunyan.createLogger({
-        name: 'framed connection keepalive tests',
-        level: process.env.LOG_LEVEL || bunyan.INFO,
-        serializers: bunyan.stdSerializers
-    });
-    LOG.addSerializers({
-        buffer: function (buf) {
-            return buf.toString();
-        }
-    });
-
     var TCP_SERVER;
     var TCP_SERVER_STREAM;
     var TCP_CLIENT_STREAM;
@@ -280,17 +256,6 @@ describe('framed-connection-keepalive', function () {
 });
 
 describe('framed-connection', function () {
-    var LOG = bunyan.createLogger({
-        name: 'framed connection tests',
-        level: process.env.LOG_LEVEL || bunyan.INFO,
-        serializers: bunyan.stdSerializers
-    });
-    LOG.addSerializers({
-        buffer: function (buf) {
-            return buf.toString();
-        }
-    });
-
     var TCP_SERVER;
     var TCP_SERVER_STREAM;
     var TCP_CLIENT_STREAM;
@@ -458,17 +423,6 @@ describe('framed-connection', function () {
 });
 
 describe('framed-connection connection errors', function () {
-    var LOG = bunyan.createLogger({
-        name: 'framed connection tests',
-        level: process.env.LOG_LEVEL || bunyan.INFO,
-        serializers: bunyan.stdSerializers
-    });
-    LOG.addSerializers({
-        buffer: function (buf) {
-            return buf.toString();
-        }
-    });
-
     var TCP_SERVER;
     var TCP_CLIENT_STREAM;
 

--- a/test/connection/lease.test.js
+++ b/test/connection/lease.test.js
@@ -2,27 +2,15 @@
 
 var net = require('net');
 var assert = require('chai').assert;
-var bunyan = require('bunyan');
 
 var reactiveSocket = require('../../lib');
+
+var LOG = require('../common/log');
 
 var PORT = process.env.PORT || 1337;
 var HOST = process.env.HOST || 'localhost';
 
 describe('Lease test', function () {
-
-    var LOG = bunyan.createLogger({
-        name: 'lease tests',
-        level: process.env.LOG_LEVEL || bunyan.INFO,
-        serializers: bunyan.stdSerializers
-    });
-
-    LOG.addSerializers({
-        buffer: function (buf) {
-            return buf.toString();
-        }
-    });
-
     var TCP_SERVER;
     var TCP_CLIENT;
     var TCP_CLIENT_STREAM;

--- a/test/connection/tcpConnection.test.js
+++ b/test/connection/tcpConnection.test.js
@@ -5,11 +5,11 @@ var net = require('net');
 
 var _ = require('lodash');
 var assert = require('chai').assert;
-var bunyan = require('bunyan');
 
 var reactiveSocket = require('../../lib');
 
 var ERROR_CODES = reactiveSocket.ERROR_CODES;
+var LOG = require('../common/log');
 
 var PORT = process.env.PORT || 1337;
 var HOST = process.env.HOST || 'localhost';
@@ -42,19 +42,6 @@ var EXPECTED_APPLICATION_ERROR = {
 };
 
 describe('TcpConnection', function () {
-
-    var LOG = bunyan.createLogger({
-        name: 'framed connection setup tests',
-        level: process.env.LOG_LEVEL || bunyan.INFO,
-        serializers: bunyan.stdSerializers
-    });
-
-    LOG.addSerializers({
-        buffer: function (buf) {
-            return buf.toString();
-        }
-    });
-
     var TCP_SERVER;
     var TCP_CLIENT;
 
@@ -206,17 +193,6 @@ describe('TcpConnection', function () {
 });
 
 describe('TcpConnection functional tests', function () {
-    var LOG = bunyan.createLogger({
-        name: 'framed connection tests',
-        level: process.env.LOG_LEVEL || bunyan.INFO,
-        serializers: bunyan.stdSerializers
-    });
-    LOG.addSerializers({
-        buffer: function (buf) {
-            return buf.toString();
-        }
-    });
-
     var TCP_SERVER;
     var TCP_SERVER_STREAM;
 

--- a/test/connection/unframedConnection.test.js
+++ b/test/connection/unframedConnection.test.js
@@ -2,7 +2,6 @@
 
 var _ = require('lodash');
 var assert = require('chai').assert;
-var bunyan = require('bunyan');
 
 var Ws = require('ws');
 var WSStream = require('yws-stream');
@@ -10,6 +9,7 @@ var WSStream = require('yws-stream');
 var reactiveSocket = require('../../lib');
 
 var ERROR_CODES = reactiveSocket.ERROR_CODES;
+var LOG = require('../common/log');
 
 var PORT = process.env.PORT || 1337;
 
@@ -30,13 +30,6 @@ var EXPECTED_APPLICATION_ERROR = {
 };
 
 describe('unframed-connection-setup', function () {
-
-    var LOG = bunyan.createLogger({
-        name: 'framed connection setup tests',
-        level: process.env.LOG_LEVEL || bunyan.INFO,
-        serializers: bunyan.stdSerializers
-    });
-
     var WS_SERVER;
     var WS_CLIENT_CONS = [];
 
@@ -148,11 +141,6 @@ describe('unframed-connection-setup', function () {
 });
 
 describe('connection', function () {
-    var LOG = bunyan.createLogger({
-        name: 'connection tests',
-        level: process.env.LOG_LEVEL || bunyan.INFO,
-        serializers: bunyan.stdSerializers
-    });
     var SERVER_CON;
     var CLIENT_CON;
     var WS_SERVER;

--- a/test/streams/framingStream.test.js
+++ b/test/streams/framingStream.test.js
@@ -2,7 +2,6 @@
 
 var _ = require('lodash');
 var assert = require('chai').assert;
-var bunyan = require('bunyan');
 
 var getRandomInt = require('../common/getRandomInt');
 
@@ -14,18 +13,9 @@ var CONSTANTS = require('../../lib/protocol/constants');
 var FLAGS = CONSTANTS.FLAGS;
 var TYPES = CONSTANTS.TYPES;
 
-describe('framing stream', function () {
-    var LOG = bunyan.createLogger({
-        name: 'framing stream test',
-        level: process.env.LOG_LEVEL || bunyan.INFO,
-        serializers: bunyan.stdSerializers
-    });
-    LOG.addSerializers({
-        buffer: function (buf) {
-            return buf.toString();
-        }
-    });
+var LOG = require('../common/log');
 
+describe('framing stream', function () {
     var FRAME = {
         type: TYPES.SETUP,
         flags: FLAGS.LEASE | FLAGS.STRICT,

--- a/test/streams/rsTcpStream.integ.test.js
+++ b/test/streams/rsTcpStream.integ.test.js
@@ -5,7 +5,6 @@ var net = require('net');
 
 var _ = require('lodash');
 var assert = require('chai').assert;
-var bunyan = require('bunyan');
 var sinon = require('sinon');
 
 var getRandomInt = require('../common/getRandomInt');
@@ -23,6 +22,8 @@ var HOST = process.env.HOST || 'localhost';
 var METADATA_ENCODING = 'utf8';
 var DATA_ENCODING = 'utf8';
 
+var LOG = require('../common/log');
+
 // we need to send a large enough frame to ensure we exceed the default TCP
 // loopback MTU of 16384 bytes. This is to test that framing actually works.
 // Hence we read in some select works of the Bard.
@@ -30,17 +31,6 @@ var HAMLET = fs.readFileSync('./test/etc/hamlet.txt', 'utf8');
 var JULIUS_CAESAR = fs.readFileSync('./test/etc/julius_caesar.txt', 'utf8');
 
 describe('RS TCP Integ Tests', function () {
-    var LOG = bunyan.createLogger({
-        name: 'rs client stream tests',
-        level: process.env.LOG_LEVEL || bunyan.INFO,
-        serializers: bunyan.stdSerializers
-    });
-    LOG.addSerializers({
-        buffer: function (buf) {
-            return buf.toString();
-        }
-    });
-
     var TCP_SERVER_STREAM;
     var TCP_SERVER;
     var SERVER_F_STREAM = new FramingStream({

--- a/test/streams/rsWsStream.integ.test.js
+++ b/test/streams/rsWsStream.integ.test.js
@@ -2,7 +2,6 @@
 
 var _ = require('lodash');
 var assert = require('chai').assert;
-var bunyan = require('bunyan');
 
 var Ws = require('ws');
 var WSStream = require('yws-stream');
@@ -20,19 +19,10 @@ var PORT = process.env.PORT || 1337;
 var METADATA_ENCODING = 'binary';
 var DATA_ENCODING = 'ascii';
 
+var LOG = require('../common/log');
+
 
 describe('RS WS Integ Tests', function () {
-    var LOG = bunyan.createLogger({
-        name: 'rs client stream tests',
-        level: process.env.LOG_LEVEL || bunyan.INFO,
-        serializers: bunyan.stdSerializers
-    });
-    LOG.addSerializers({
-        buffer: function (buf) {
-            return buf.toString();
-        }
-    });
-
     var WS_SERVER;
     var WS_CLIENT;
     var WS_SERVER_STREAM;

--- a/test/streams/serializeParseStream.test.js
+++ b/test/streams/serializeParseStream.test.js
@@ -2,7 +2,6 @@
 
 var _ = require('lodash');
 var assert = require('chai').assert;
-var bunyan = require('bunyan');
 
 var getRandomInt = require('../common/getRandomInt');
 
@@ -12,13 +11,9 @@ var ParseStream = require('../../lib/streams/parseStream.js');
 var CONSTANTS = require('../../lib/protocol/constants');
 var FLAGS = CONSTANTS.FLAGS;
 var TYPES = CONSTANTS.TYPES;
+var LOG = require('../common/log');
 
 describe('serialize/parse streams', function () {
-    var LOG = bunyan.createLogger({
-        name: 'rs client stream tests',
-        level: process.env.LOG_LEVEL || bunyan.INFO,
-        serializers: bunyan.stdSerializers
-    });
     var S_STREAM = new SerializeStream({
         log: LOG,
         metadataEncoding: 'utf-8',


### PR DESCRIPTION
This PR fixes the following issues with the LB.

* If there are no available connections initially, we are still firing the `connected` and `ready` events
* If we initially don't have enough hosts to satisfy `pool_size`, then we will never go up to the maximum number of connections, even if after on there are enough hosts. This is also a problem if the pool re-sizes below `pool_size`, if hosts are updated.
* We were not diffing the hosts properly on update. If we updated the pool with the same set of hosts that are already in the pool, then the hosts show up in both connected and free lists.

There are also some minor changes. The number of connections in the pool is no longer optional. Loggers now respect the level of their parents.

@stevegury Please take a look.