### PR TITLE
Loadbalancer: Implement simple 'Power of 2 Choices' algo

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -93,6 +93,7 @@ function Connection(opts) {
     this._keepalive = opts.keepalive || 1 * 1000;
     this._leaseNumberOfRequests = 0; // how many messages I'm allowed to send
     this._leaseExpirationDate = Date.now(); // date when the lease expire
+
     if (!opts.lease) {
         self._leaseNumberOfRequests = Number.MAX_VALUE;
         self._leaseExpirationDate = Number.MAX_VALUE;

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -93,6 +93,10 @@ function Connection(opts) {
     this._keepalive = opts.keepalive || 1 * 1000;
     this._leaseNumberOfRequests = 0; // how many messages I'm allowed to send
     this._leaseExpirationDate = Date.now(); // date when the lease expire
+    if (!opts.lease) {
+        self._leaseNumberOfRequests = Number.MAX_VALUE;
+        self._leaseExpirationDate = Number.MAX_VALUE;
+    }
     this._requestTimeoutMs = opts.requestTimeoutMs || 30 * 1000;
     // TODO: we don't use this today
     this._maxLifetime = opts.maxLifetime || 10 * 1000;
@@ -427,10 +431,11 @@ Connection.prototype._handleSetup = function _handleSetup(frame) {
         // This dummy strategy, grant leases to every clients at a maximum rate
         // of 2^30 requests per 5 seconds
         var budget = 1 << 30;
+        var intervalMs = 5000;
         self.sendLease(budget, 1000);
         var ticker = setInterval(function leaseTicker() {
-            self.sendLease(budget, 1000);
-        }, 5000);
+            self.sendLease(budget, intervalMs + 1000);
+        }, intervalMs);
         self._timers.push(ticker);
     }
 

--- a/lib/connection/tcpLoadBalancer.js
+++ b/lib/connection/tcpLoadBalancer.js
@@ -10,6 +10,7 @@ var assert = require('assert-plus');
 var TcpConnection = require('./tcpConnection');
 
 var LOG = require('../logger');
+var EFFORT = 5;
 
 /**
  * RS TCP based client side load balancer.
@@ -93,22 +94,54 @@ function TcpLoadBalancer(opts) {
         type: 'client'
     }, opts.rsOpts);
 
+    // 'Power of 2 Choices'' strategy (use `availability` as the load function)
+    // c.f. https://www.eecs.harvard.edu/~michaelm/postscripts/mythesis.pdf
+    function p2c() {
+        var availableConnections = _.values(self._connections.connected);
+        var n = availableConnections.length;
 
-    this._strategy = opts.strategy || random;
+        if (n === 0) {
+            return null;
+        }
+
+        if (n === 1) {
+            return availableConnections.connected[0].getConnection();
+        }
+
+        var conn1 = null;
+        var conn2 = null;
+
+        for (var e = 0; e < EFFORT; e++) {
+            // i1, i2 are 2 *different* random numbers in [0, n]
+            var i1 = Math.floor(Math.random() * n);
+            var i2 = Math.floor(Math.random() * (n - 1));
+
+            if (i2 >= i1) {
+                i2++;
+            }
+
+            conn1 = availableConnections[i1].getConnection();
+            conn2 = availableConnections[i2].getConnection();
+
+            if (conn1 && conn1.availability() > 0
+                && conn2 && conn2.availability() > 0) {
+                break;
+            }
+        }
+        if (!conn2) {
+            return conn1;
+        } else if (conn1 && conn1.availability() > conn2.availability()) {
+            return conn1;
+        } else {
+            return conn2;
+        }
+    }
+
+    this._strategy = opts.strategy || p2c;
 
     // seed the pool with connections
     for (var i = 0; i < self._size; i++) {
         self._connect();
-    }
-
-    // random pick a connected server
-    function random() {
-        var connection = _.sample(self._connections.connected);
-
-        if (connection) {
-            return connection.getConnection();
-        }
-        return null;
     }
 }
 util.inherits(TcpLoadBalancer, EventEmitter);

--- a/lib/connection/tcpLoadBalancer.js
+++ b/lib/connection/tcpLoadBalancer.js
@@ -128,6 +128,7 @@ function TcpLoadBalancer(opts) {
                 break;
             }
         }
+
         if (!conn2) {
             return conn1;
         } else if (conn1 && conn1.availability() > conn2.availability()) {

--- a/test/connection/tcpLoadBalancer.test.js
+++ b/test/connection/tcpLoadBalancer.test.js
@@ -6,6 +6,7 @@ var _ = require('lodash');
 var assert = require('chai').assert;
 
 var reactiveSocket = require('../../lib');
+var getSemaphore = require('../common/getSemaphore');
 
 var ERROR_CODES = reactiveSocket.ERROR_CODES;
 var LOG = require('../common/log');
@@ -141,14 +142,10 @@ describe('TcpLoadBalancer', function () {
     }
 
     beforeEach(function (done) {
-        var count = 0;
+        var semaphore = getSemaphore(_.keys(SERVER_CFG).length, done);
         _.concat(SERVER_CFG, EXTRA_SERVER_CFG).forEach(function (cfg) {
             createServer(cfg, function () {
-                count++;
-
-                if (count === _.keys(SERVER_CFG).length) {
-                    done();
-                }
+                semaphore.latch();
             });
         });
     });
@@ -156,14 +153,10 @@ describe('TcpLoadBalancer', function () {
     afterEach(function (done) {
         CONNECTION_POOL.close();
         SERVER_CONNECTION_COUNT = 0;
-        var count = 0;
+        var semaphore = getSemaphore(_.keys(SERVER_CFG).length, done);
         _(SERVERS).forEach(function (s) {
             s.close(function () {
-                count++;
-
-                if (count === _.keys(SERVER_CFG).length) {
-                    done();
-                }
+                semaphore.latch();
             });
         });
 


### PR DESCRIPTION
Update the default loadbalancing strategy to 'The Power of 2 choices',
it may seem marginaly better than random loadbalancing but it is actually
asymptotically equivalent to JSQ (Join the Shortest Queue).

Also, the strategy now look at the availability of the connection before
dispatching the request.