### PR TITLE
ReactiveSocket deal with stream error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
     - secure: "NeBjrpBxfbE9jW4NDgeiMHfI5P4C2BDcR2kchSubntNBOfDENaNav0x9MRUVmH9o531X5uMcTadFBQJWAeGxbQRK7CvZGdHDfPKWyjcf2o7SYHAceDMk18f0jeeay2v+MpH/h0pV6MAn/ypjIHK1TuRwCtjTTJTcVknA3im6Fb7iQASz40aRJ71ZqlzNq8yVFOiMqo00Z6iuZlVwsOeF9qHI87Y/8xmTXCEountLwd/xLyA3btejmAvaFnc2fDC9Zyzz++dQ8RhiO1xkovUxUDvy02mXMXPph64ZeUwte8lmO4OXWcJQTrus399HCXDxt81CohQDa5+AYYQUH8jVRrdTdZcYC1+zhkwJztaAEgqLnwOoOAdoFdN0gBOx6fKXb3/c+fLJOM/zo5OmjVxWD6XgBq031KqI05wMtmcFxMXHWctIeUCQjNCL8PB617Y76+TxQTVtIZ8CStoHkGupYdDOfPgCmpPL+3PWMmIH0eTvUiGgZv7D+gt8TZYMtMBSW4adyMVbo9JxiLMscPve5HdaQvXtNCb8OzpoSdlVi5p391kUcHUmiSEytQYwG0bGncCq32KhsmXZWm2UOK45xoWTpHoij5vO7VMZ1OxIvRxE8f7qA8wrMmfYTK9XCwQf7MbDoYuMCOMR5O4btAqH8ma/OqR5xv6r28qSLTcPVC8="
 
 node_js:
+    - "6"
     - "5"
     - "4"
 
@@ -28,5 +29,5 @@ after_script:
 
 notifications:
     email:
-        yunong@netflix.com
-
+        uiplatform@netflix.com
+        edge-platform@netflix.com

--- a/lib/connection/loadBalancer.js
+++ b/lib/connection/loadBalancer.js
@@ -340,6 +340,9 @@ LoadBalancer.prototype._addSocket = function _addSocket(factory) {
             inactivityPeriodMs: self._inactivityPeriodMs,
             medianBufferSize: 64
         });
+        socket.on('error', function () {
+            LoadBalancer.prototype._removeSocket(socket);
+        });
         socket.on('close', function () {
             if (!self._closed) {
                 self._log.debug('Loadbalancer.selectSlowSocket: ' +

--- a/lib/connection/reactiveSocket.js
+++ b/lib/connection/reactiveSocket.js
@@ -120,6 +120,9 @@ function ReactiveSocket(opts) {
     this._requestTimeoutMs = opts.requestTimeoutMs || 30 * 1000;
     // TODO: we don't use this today
     this._maxLifetime = opts.maxLifetime || 10 * 1000;
+
+    this._isClosed = false;
+
     // maps a streamId from the server to a client interaction.
     this._streams = {
         // as we add 2 to the latest streamId, this create id starting at 2
@@ -138,6 +141,12 @@ function ReactiveSocket(opts) {
         metadataEncoding: self._metadataEncoding
     });
     this._transportStream = opts.transport.stream;
+
+    self.on('error', function (err) {
+        if (err) {
+            self.close();
+        }
+    });
 
     var transportStreamErr;
     self._transportStream.once('close', function onClose() {
@@ -226,8 +235,8 @@ function ReactiveSocket(opts) {
             case TYPES.EXT:
             default:
                 self.emit('error',
-                          new Error(frame.header.type +
-                                    ' frame not supported'));
+                    new Error(frame.header.type +
+                        ' frame not supported'));
                 break;
         }
     });
@@ -422,6 +431,10 @@ ReactiveSocket.prototype.sendLease = function send(numberOfRequest, ttl) {
 ReactiveSocket.prototype.availability = function availability() {
     var self = this;
 
+    if (self._isClosed) {
+        return 0.0;
+    }
+
     var inLeaseWindow = self._leaseNumberOfRequests > 0
         && self._leaseExpirationDate >= Date.now();
     var availabilityValue = inLeaseWindow ? 1.0 : 0.0;
@@ -446,6 +459,8 @@ ReactiveSocket.prototype.close = function close(cb) {
     if (cb) {
         cb();
     }
+    self._isClosed = true;
+    self.emit('close', self);
 };
 
 

--- a/test/connection/reactivesocket.test.js
+++ b/test/connection/reactivesocket.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var assert = require('chai').assert;
+var Duplex = require('stream').Duplex;
+var util = require('util');
+
+var getSemaphore = require('../../lib/common/getSemaphore');
+var ReactiveSocket =
+    require('../../lib/connection/reactiveSocket');
+
+
+function ReadFailingStream(options) {
+    Duplex.call(this, options);
+}
+util.inherits(ReadFailingStream, Duplex);
+
+ReadFailingStream.prototype._read = function readBytes(n) {
+    console.log('erroring read');
+    this.emit('error', new Error());
+};
+
+ReadFailingStream.prototype._write = function (chunk, enc, cb) {
+    cb();
+};
+
+
+describe('ReactiveSocket', function () {
+    it('Create a ReactiveSocket', function (done) {
+        var rs = new ReactiveSocket({
+            transport: {
+                stream: new ReadFailingStream()
+            },
+            type: 'client'
+        });
+
+        var semaphore = getSemaphore(2, function () {
+            assert(rs.availability() === 0.0, 'RS availability is now 0.0');
+            done();
+        });
+
+        rs.once('error', function (res) {
+            semaphore.latch();
+        });
+
+        rs.once('close', function (res) {
+            semaphore.latch();
+        });
+
+        rs.request({data: 'data', metadata: ''}).on('response', function (res) {
+            assert(false, 'Shouldn\'t receive a response!');
+        });
+    });
+});

--- a/test/connection/tcpLoadBalancer.test.js
+++ b/test/connection/tcpLoadBalancer.test.js
@@ -368,7 +368,6 @@ describe('TcpLoadBalancer', function () {
             var count = 0;
             // close all connections manually
             _.forEach(CONNECTION_POOL._connections.connected, function (c) {
-                c.close();
                 c.on('close', function () {
                     count++;
                     // check that all these connections are still in the pool
@@ -379,6 +378,8 @@ describe('TcpLoadBalancer', function () {
                         }, 100);
                     }
                 });
+
+                c.close();
             });
         });
     });


### PR DESCRIPTION
Previously when the underlying transport stream was emitting an error, the system was crashing since nobody was listening to the event.

Now the ReactiveSocket class listen to the event and add extra protection for updating the availability right away.
The loadbalancer remove the ReactiveSocket from its list as soon as it errors.