### PR TITLE
Fix bug in utf8 data length computation

### DIFF
--- a/lib/protocol/frame/computeFrameLength.js
+++ b/lib/protocol/frame/computeFrameLength.js
@@ -43,11 +43,11 @@ function computeFrameLength(frame) {
 
     if (frame.metadata) {
         length += METADATA_LENGTH;
-        length += frame.metadata.length;
+        length += Buffer.byteLength(frame.metadata, frame.metadataEncoding);
     }
 
     if (frame.data) {
-        length += frame.data.length;
+        length += Buffer.byteLength(frame.data, frame.dataEncoding);
     }
 
     return length;

--- a/lib/protocol/frame/writeFrameData.js
+++ b/lib/protocol/frame/writeFrameData.js
@@ -23,7 +23,8 @@ function writeFrameData(frame, output, offset) {
     if (frame.metadata) {
         assert.string(frame.metadataEncoding, 'frame.metadataEncoding');
 
-        var mdLength = Buffer.byteLength(frame.metadata, frame.metadataEncoding);
+        var mdLength = Buffer.byteLength(
+            frame.metadata, frame.metadataEncoding);
         output.writeUInt32BE(mdLength + METADATA_LENGTH, offset);
         offset += METADATA_LENGTH;
         writtenBytes += METADATA_LENGTH;

--- a/lib/protocol/frame/writeFrameData.js
+++ b/lib/protocol/frame/writeFrameData.js
@@ -23,7 +23,7 @@ function writeFrameData(frame, output, offset) {
     if (frame.metadata) {
         assert.string(frame.metadataEncoding, 'frame.metadataEncoding');
 
-        var mdLength = frame.metadata.length;
+        var mdLength = Buffer.byteLength(frame.metadata, frame.metadataEncoding);
         output.writeUInt32BE(mdLength + METADATA_LENGTH, offset);
         offset += METADATA_LENGTH;
         writtenBytes += METADATA_LENGTH;

--- a/test/frame/frame.test.js
+++ b/test/frame/frame.test.js
@@ -219,6 +219,27 @@ describe('request response', function cb() {
         assert.equal(actualFrame.data, seedFrame.data);
 
     });
+
+    it('encode/decode with utf8 chars', function () {
+        var seedFrame = {
+            metadataEncoding: 'utf8',
+            dataEncoding: 'utf8',
+            streamId: getRandomInt(0, Math.pow(2, 32)),
+            metadata: 'rüüückt',
+            data: 'veürrücküter'
+        };
+
+        var actualFrame = frame.parseFrame(
+            frame.getReqResFrame(seedFrame), 'utf8', 'utf8');
+        assert.isObject(actualFrame.header);
+        assert.equal(actualFrame.header.streamId, seedFrame.streamId);
+        assert.equal(actualFrame.header.type, CONSTANTS.TYPES.REQUEST_RESPONSE);
+        assert.equal(actualFrame.header.flags, CONSTANTS.FLAGS.METADATA);
+        assert.equal(actualFrame.metadata, seedFrame.metadata);
+        assert.equal(actualFrame.data, seedFrame.data);
+
+    });
+
 });
 
 describe('response', function () {
@@ -238,6 +259,27 @@ describe('response', function () {
         assert.equal(actualFrame.header.type, CONSTANTS.TYPES.RESPONSE);
         assert.equal(actualFrame.header.flags,
                      CONSTANTS.FLAGS.METADATA | CONSTANTS.FLAGS.COMPLETE);
+        assert.equal(actualFrame.metadata, seedFrame.metadata);
+        assert.equal(actualFrame.data, seedFrame.data);
+    });
+
+    it('encode/decode w/ utf8 data, utf8 metadata, and complete', function () {
+        var seedFrame = {
+            metadataEncoding: 'utf8',
+            dataEncoding: 'utf8',
+            streamId: getRandomInt(0, Math.pow(2, 32)),
+            flags: CONSTANTS.FLAGS.COMPLETE,
+            metadata: 'rüüückt',
+            data: 'veürrücküter'
+        };
+
+        var actualFrame = frame.parseFrame(
+            frame.getResponseFrame(seedFrame), 'utf8', 'utf8');
+        assert.isObject(actualFrame.header);
+        assert.equal(actualFrame.header.streamId, seedFrame.streamId);
+        assert.equal(actualFrame.header.type, CONSTANTS.TYPES.RESPONSE);
+        assert.equal(actualFrame.header.flags,
+            CONSTANTS.FLAGS.METADATA | CONSTANTS.FLAGS.COMPLETE);
         assert.equal(actualFrame.metadata, seedFrame.metadata);
         assert.equal(actualFrame.data, seedFrame.data);
     });


### PR DESCRIPTION
The current version of the code use `string.length` to compute the length of
the data/metadata. This is obviously wrong in the case of utf8 strings, we need
to use `Buffer.byteLength(string, encoding)` instead.

I also added two test that ensure that data/metadata are correctly
serialize/deserialize.